### PR TITLE
test: first GitHub Actions run (do not merge)

### DIFF
--- a/apps/docs/docs/development.md
+++ b/apps/docs/docs/development.md
@@ -37,3 +37,5 @@ Then you can run the command in the wanted project and test your changes.
 There are some [examples](/docs/examples) that double for snapshot-testing.
 
 Please add more examples there. If you need to update the snapshots, run `yarn test:update` in the root directory.
+
+<!-- github actions pipeline smoke test -->


### PR DESCRIPTION
Smoke test for the github backend. Base is `next`, which carries the generated workflows.

Also a diagnostic: the `next` → `main` PR (#1) produced no runs at all, which suggests github resolves workflows from the base/default branch rather than the PR head — `main` has none yet. If this one runs, that confirms it.

Do not merge; I close it once the run is observed.