### PR TITLE
fix(github): lower allow_failure to continue-on-error

### DIFF
--- a/.changeset/patch-github-allow-failure.md
+++ b/.changeset/patch-github-allow-failure.md
@@ -1,0 +1,5 @@
+---
+"catladder": patch
+---
+
+`allowFailure` now works on the github backend. The flag was lowered for gitlab only and silently dropped for github, so a job marked as non-blocking failed the whole workflow — and with it every job depending on it. The `pages` deploy type is the worst case: it is `allowFailure` by default precisely so a broken site publish cannot block the pipeline, but on github a failed publish also skipped the release job. It now lowers to `continue-on-error`.

--- a/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
@@ -317,6 +317,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -767,6 +768,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/changesets-releases-auto.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/changesets-releases-auto.test.ts.snap
@@ -325,6 +325,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -775,6 +776,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
@@ -376,6 +376,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -796,6 +797,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_app_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_app_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
@@ -418,6 +418,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_web_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_web_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -891,6 +892,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_web_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_web_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -794,6 +795,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_db_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_db_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -572,6 +573,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -1032,6 +1034,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_db_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_db_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -1236,6 +1239,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -794,6 +795,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_dev_api_DB_PASSWORD: \${{ secrets.CL_dev_api_DB_PASSWORD }}
@@ -794,6 +795,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_review_api_DB_PASSWORD: \${{ secrets.CL_review_api_DB_PASSWORD }}

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_db1_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_db1_GCLOUD_DEPLOY_credentialsKey }}
         CL_dev_db1_DB_PASSWORD: \${{ secrets.CL_dev_db1_DB_PASSWORD }}
@@ -578,6 +579,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_db2_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_db2_GCLOUD_DEPLOY_credentialsKey }}
         CL_dev_db2_DB_PASSWORD: \${{ secrets.CL_dev_db2_DB_PASSWORD }}
@@ -788,6 +790,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_dev_api_DB_PASSWORD: \${{ secrets.CL_dev_api_DB_PASSWORD }}
@@ -1216,6 +1219,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_db1_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_db1_GCLOUD_DEPLOY_credentialsKey }}
         CL_review_db1_DB_PASSWORD: \${{ secrets.CL_review_db1_DB_PASSWORD }}
@@ -1426,6 +1430,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_db2_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_db2_GCLOUD_DEPLOY_credentialsKey }}
         CL_review_db2_DB_PASSWORD: \${{ secrets.CL_review_db2_DB_PASSWORD }}
@@ -1636,6 +1641,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_review_api_DB_PASSWORD: \${{ secrets.CL_review_api_DB_PASSWORD }}

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_dev_api_DB_PASSWORD: \${{ secrets.CL_dev_api_DB_PASSWORD }}
@@ -578,6 +579,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_worker_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_worker_GCLOUD_DEPLOY_credentialsKey }}
         CL_dev_worker_DB_PASSWORD: \${{ secrets.CL_dev_worker_DB_PASSWORD }}
@@ -1006,6 +1008,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_review_api_DB_PASSWORD: \${{ secrets.CL_review_api_DB_PASSWORD }}
@@ -1216,6 +1219,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_worker_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_worker_GCLOUD_DEPLOY_credentialsKey }}
         CL_review_worker_DB_PASSWORD: \${{ secrets.CL_review_worker_DB_PASSWORD }}

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_dev_api_DB_PASSWORD: \${{ secrets.CL_dev_api_DB_PASSWORD }}
@@ -794,6 +795,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_review_api_DB_PASSWORD: \${{ secrets.CL_review_api_DB_PASSWORD }}

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
@@ -266,6 +266,7 @@ catladder-main.yml:
           image: job-service-1
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: audit-image
@@ -523,6 +524,7 @@ catladder-review.yml:
           image: job-service-1
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: audit-image

--- a/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_DEPLOY_API_KEY: \${{ secrets.CL_dev_www_DEPLOY_API_KEY }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -792,6 +793,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_DEPLOY_API_KEY: \${{ secrets.CL_review_www_DEPLOY_API_KEY }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -783,6 +784,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
@@ -316,6 +316,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -450,6 +451,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -584,6 +586,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -884,6 +887,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -817,6 +818,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_app_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_app_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
@@ -416,6 +416,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -877,6 +878,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
@@ -418,6 +418,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_POSTGRESQL_PASSWORD: \${{ secrets.CL_dev_api_POSTGRESQL_PASSWORD }}
         CL_dev_api_cloudsqlProxyCredentials: \${{ secrets.CL_dev_api_cloudsqlProxyCredentials }}
@@ -901,6 +902,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_POSTGRESQL_PASSWORD: \${{ secrets.CL_review_api_POSTGRESQL_PASSWORD }}
         CL_review_api_cloudsqlProxyCredentials: \${{ secrets.CL_review_api_cloudsqlProxyCredentials }}

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
@@ -416,6 +416,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -611,6 +612,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -1072,6 +1074,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -1267,6 +1270,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
@@ -418,6 +418,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_MONGODB_ROOT_PASSWORD: \${{ secrets.CL_dev_api_MONGODB_ROOT_PASSWORD }}
         CL_dev_api_MONGODB_REPLICASET_KEY: \${{ secrets.CL_dev_api_MONGODB_REPLICASET_KEY }}
@@ -901,6 +902,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_MONGODB_ROOT_PASSWORD: \${{ secrets.CL_review_api_MONGODB_ROOT_PASSWORD }}
         CL_review_api_MONGODB_REPLICASET_KEY: \${{ secrets.CL_review_api_MONGODB_REPLICASET_KEY }}

--- a/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
@@ -468,6 +468,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_web_MONGODB_ROOT_PASSWORD: \${{ secrets.CL_dev_web_MONGODB_ROOT_PASSWORD }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -999,6 +1000,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_web_MONGODB_ROOT_PASSWORD: \${{ secrets.CL_review_web_MONGODB_ROOT_PASSWORD }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
@@ -316,6 +316,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -616,6 +617,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
@@ -316,6 +316,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -616,6 +617,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
@@ -418,6 +418,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app1_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_app1_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -622,6 +623,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app2_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_app2_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -824,6 +826,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -1287,6 +1290,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app1_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_app1_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -1491,6 +1495,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app2_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_app2_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -1693,6 +1698,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app_APP_STORE_CONNECT_API_KEY_CONTENT: \${{ secrets.CL_dev_app_APP_STORE_CONNECT_API_KEY_CONTENT }}
         CL_dev_app_APP_STORE_CONNECT_ISSUER_ID: \${{ secrets.CL_dev_app_APP_STORE_CONNECT_ISSUER_ID }}
@@ -567,6 +568,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -987,6 +989,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app_APP_STORE_CONNECT_API_KEY_CONTENT: \${{ secrets.CL_review_app_APP_STORE_CONNECT_API_KEY_CONTENT }}
         CL_review_app_APP_STORE_CONNECT_ISSUER_ID: \${{ secrets.CL_review_app_APP_STORE_CONNECT_ISSUER_ID }}
@@ -1186,6 +1189,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_api_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_api_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -783,6 +784,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
@@ -317,6 +317,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_lib_NPM_TOKEN: \${{ secrets.CL_dev_lib_NPM_TOKEN }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -743,6 +744,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_lib_NPM_TOKEN: \${{ secrets.CL_review_lib_NPM_TOKEN }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_my_app_MY_SECRET: \${{ secrets.CL_dev_my_app_MY_SECRET }}
         CL_dev_my_app_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_my_app_GCLOUD_DEPLOY_credentialsKey }}
@@ -794,6 +795,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_my_app_MY_SECRET: \${{ secrets.CL_review_my_app_MY_SECRET }}
         CL_review_my_app_MY_REVIEW_SECRET: \${{ secrets.CL_review_my_app_MY_REVIEW_SECRET }}

--- a/packages/pipeline/examples/__snapshots__/pages-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pages-deploy.test.ts.snap
@@ -274,6 +274,7 @@ catladder-main.yml:
         packages: read
         pages: write
         id-token: write
+      continue-on-error: true
       env:
         PAGES_PREFIX: ''
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
@@ -369,6 +369,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -789,6 +790,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
@@ -368,6 +368,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
@@ -788,6 +789,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8

--- a/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
@@ -366,6 +366,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -835,6 +836,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
@@ -313,6 +313,7 @@ catladder-main.yml:
         image: ruby:3.2.1
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app_SECRET_KEY_BASE: \${{ secrets.CL_dev_app_SECRET_KEY_BASE }}
         CL_dev_app_POSTGRESQL_PASSWORD: \${{ secrets.CL_dev_app_POSTGRESQL_PASSWORD }}
@@ -600,6 +601,7 @@ catladder-review.yml:
         image: ruby:3.2.1
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app_SECRET_KEY_BASE: \${{ secrets.CL_review_app_SECRET_KEY_BASE }}
         CL_review_app_POSTGRESQL_PASSWORD: \${{ secrets.CL_review_app_POSTGRESQL_PASSWORD }}

--- a/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
@@ -418,6 +418,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app1_SECRET1: \${{ secrets.CL_dev_app1_SECRET1 }}
         CL_dev_app1_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_app1_GCLOUD_DEPLOY_credentialsKey }}
@@ -628,6 +629,7 @@ catladder-main.yml:
           password: \${{ github.token }}
       environment:
         name: dev
+      continue-on-error: true
       env:
         CL_dev_app2_SECRET2: \${{ secrets.CL_dev_app2_SECRET2 }}
         CL_dev_app2_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_app2_GCLOUD_DEPLOY_credentialsKey }}
@@ -838,6 +840,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -1307,6 +1310,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app1_SECRET1: \${{ secrets.CL_review_app1_SECRET1 }}
         CL_review_app1_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_app1_GCLOUD_DEPLOY_credentialsKey }}
@@ -1517,6 +1521,7 @@ catladder-review.yml:
           password: \${{ github.token }}
       environment:
         name: review
+      continue-on-error: true
       env:
         CL_review_app2_SECRET2: \${{ secrets.CL_review_app2_SECRET2 }}
         CL_review_app2_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_app2_GCLOUD_DEPLOY_credentialsKey }}
@@ -1727,6 +1732,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
@@ -316,6 +316,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -480,6 +481,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -811,6 +813,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -975,6 +978,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
@@ -366,6 +366,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -844,6 +845,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
@@ -366,6 +366,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -841,6 +842,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
@@ -366,6 +366,7 @@ catladder-main.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:
@@ -874,6 +875,7 @@ catladder-review.yml:
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
+      continue-on-error: true
       env:
         CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:64e36cb505a8
       steps:

--- a/packages/pipeline/src/backends/github/createGithubJobs.ts
+++ b/packages/pipeline/src/backends/github/createGithubJobs.ts
@@ -481,6 +481,12 @@ export const makeGithubJob = (
     ...(Object.keys(services).length > 0 ? { services } : {}),
     ...(githubEnvironment ? { environment: githubEnvironment } : {}),
     ...(permissions ? { permissions } : {}),
+    // gitlab's allow_failure has a direct github counterpart. Without
+    // this the flag was silently dropped: a `pages` deploy (allowFailure
+    // by default, so a broken site publish cannot block the pipeline)
+    // failed the whole workflow — and took every job that needs it,
+    // including the release, down with it.
+    ...(job.allow_failure ? { "continue-on-error": true } : {}),
     env,
     steps: [
       ...(skipCheckout


### PR DESCRIPTION
First PR on github 🎉

`allow_failure` was lowered by the gitlab backend only — `createGithubJobs` dropped it entirely. A job explicitly marked non-blocking therefore failed the whole workflow run, and every job depending on it was skipped.

### Why this is urgent rather than cosmetic

The `pages` deploy type defaults to `allowFailure: true`, with the comment *"a broken site publish should not block the rest of the pipeline"*. On github it did block it — and `create-release` lists `docs-deploy-dev` in its `needs`, so **a failing docs publish would have silently skipped the v5 release**.

That path is the one thing still untested: `docs` review is off and pages only deploys from `main`, so `upload-pages-artifact` running inside a `container:` first executes on the release commit itself. Found while checking exactly that.

### Change

One conditional in `createGithubJobs`, mapping `allow_failure` to `continue-on-error`.

Snapshots are purely additive: **145 `continue-on-error: true` lines added, nothing removed**. 264/264 pass.