### PR TITLE
chore: regenerate workflows so allow_failure actually applies

### DIFF
--- a/.github/workflows/catladder-main.yml
+++ b/.github/workflows/catladder-main.yml
@@ -178,6 +178,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ github.token }}
+    continue-on-error: true
     env:
       CL_JOB_IMAGE: ghcr.io/${{ github.repository }}/catladder/jobs-default:8c93778931df
     steps:
@@ -359,6 +360,7 @@ jobs:
       packages: read
       pages: write
       id-token: write
+    continue-on-error: true
     env:
       PAGES_PREFIX: ''
       CL_JOB_IMAGE: ghcr.io/${{ github.repository }}/catladder/jobs-default:8c93778931df

--- a/.github/workflows/catladder-review.yml
+++ b/.github/workflows/catladder-review.yml
@@ -183,6 +183,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ github.token }}
+    continue-on-error: true
     env:
       CL_JOB_IMAGE: ghcr.io/${{ github.repository }}/catladder/jobs-default:8c93778931df
     steps:


### PR DESCRIPTION
Follow-up to #3, and a gap I left there.

#3 taught `createGithubJobs` to lower `allow_failure` → `continue-on-error` and updated the **example snapshots** — but I never re-ran `catenv`, so **this repository's own committed workflows never gained the flag**. The fix was in the code and missing from the pipeline that actually runs.

Three jobs gain it:

| job | why it matters |
|---|---|
| `docs-deploy-dev` | **the important one.** `create-release` lists it in `needs`, so a failed site publish would *still* have skipped the v5 release — precisely the failure #3 set out to prevent |
| `ws-base-audit-dev` | security audit, non-blocking by configuration |
| `ws-base-audit-review` | same, on review |

Found by regenerating a clean checkout of `next` and diffing — worth doing before the release rather than discovering it when the release silently doesn't happen.

3 lines. 264/264 pass.