### PR TITLE
fix(gitlab): release executor only needs the pipeline's sink jobs

### DIFF
--- a/.changeset/patch-release-executor-needs-frontier.md
+++ b/.changeset/patch-release-executor-needs-frontier.md
@@ -1,0 +1,5 @@
+---
+"catladder": patch
+---
+
+The queued-release executor (`🚀 release once pipeline succeeds`) now only `needs:` the sink jobs of the main-branch pipeline — the deploy/verify tips and terminal quality jobs — instead of every automatic job. `needs:` is transitive, so the coverage is identical (a failed ancestor still skips its descendants and with them the executor), but the needs list stays far below GitLab's 50-entry cap: large multi-component pipelines that previously fell back to the legacy after-the-pipeline release button get the click-any-time queueing back.

--- a/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
@@ -3471,20 +3471,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image changesets
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
@@ -3454,20 +3454,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'app 🛡 audit | dev '
-      optional: true
-    - job: 'app 👮 lint | dev '
-      optional: true
-    - job: 'app 🧪 test | dev '
-      optional: true
-    - job: 'app 🔨 app | dev '
-      optional: true
-    - job: 'app 🔨 docker | dev '
-      optional: true
     - job: 'app 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
@@ -3782,22 +3782,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image jobs-meteor
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'web 🛡 audit | dev '
-      optional: true
-    - job: 'web 👮 lint | dev '
-      optional: true
-    - job: 'web 🧪 test | dev '
-      optional: true
-    - job: 'web 🔨 app | dev '
-      optional: true
-    - job: 'web 🔨 docker | dev '
-      optional: true
     - job: 'web 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
@@ -3462,20 +3462,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
@@ -3538,20 +3538,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
@@ -3455,20 +3455,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
@@ -3502,20 +3502,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
@@ -3502,20 +3502,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
@@ -3506,20 +3506,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-storybook.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-storybook.test.ts.snap
@@ -2980,14 +2980,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
@@ -5790,34 +5790,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'db 🛡 audit | dev '
-      optional: true
-    - job: 'db 👮 lint | dev '
-      optional: true
-    - job: 'db 🧪 test | dev '
-      optional: true
-    - job: 'db 🔨 app | dev '
-      optional: true
-    - job: 'db 🔨 docker | dev '
-      optional: true
-    - job: 'db 🚀 Deploy | dev '
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
-    - job: 'api 🚀 Deploy | dev '
-      optional: true
     - job: 'api 🔍 verify | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
@@ -3507,22 +3507,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image agent-claude
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
     - job: claude claude-agent-event

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
@@ -3438,20 +3438,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
@@ -3775,20 +3775,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
@@ -8175,43 +8175,9 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'db1 🛡 audit | dev '
-      optional: true
-    - job: 'db1 👮 lint | dev '
-      optional: true
-    - job: 'db1 🧪 test | dev '
-      optional: true
-    - job: 'db1 🔨 app | dev '
-      optional: true
-    - job: 'db1 🔨 docker | dev '
-      optional: true
     - job: 'db1 🚀 Deploy | dev '
       optional: true
-    - job: 'db2 🛡 audit | dev '
-      optional: true
-    - job: 'db2 👮 lint | dev '
-      optional: true
-    - job: 'db2 🧪 test | dev '
-      optional: true
-    - job: 'db2 🔨 app | dev '
-      optional: true
-    - job: 'db2 🔨 docker | dev '
-      optional: true
     - job: 'db2 🚀 Deploy | dev '
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
       optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
@@ -5832,31 +5832,7 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
-      optional: true
-    - job: 'worker 🛡 audit | dev '
-      optional: true
-    - job: 'worker 👮 lint | dev '
-      optional: true
-    - job: 'worker 🧪 test | dev '
-      optional: true
-    - job: 'worker 🔨 app | dev '
-      optional: true
-    - job: 'worker 🔨 docker | dev '
       optional: true
     - job: 'worker 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
@@ -3871,20 +3871,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
@@ -3444,20 +3444,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
@@ -3444,20 +3444,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
@@ -2799,18 +2799,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/custom-build-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-build-job.test.ts.snap
@@ -2455,12 +2455,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
@@ -2906,20 +2906,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
@@ -3450,20 +3450,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
@@ -2289,8 +2289,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
     - job: 'api 🛡 audit | dev '
       optional: true
     - job: 'api 👮 lint | dev '

--- a/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
@@ -3758,22 +3758,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
-    - job: 'www 🚀 Deploy | dev '
-      optional: true
     - job: 'www e2e | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
@@ -3439,20 +3439,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'app 🛡 audit | dev '
-      optional: true
-    - job: 'app 👮 lint | dev '
-      optional: true
-    - job: 'app 🧪 test | dev '
-      optional: true
-    - job: 'app 🔨 app | dev '
-      optional: true
-    - job: 'app 🔨 docker | dev '
-      optional: true
     - job: 'app 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
@@ -4483,22 +4483,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
@@ -4583,22 +4583,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
@@ -6951,33 +6951,7 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
       optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
@@ -4707,22 +4707,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
@@ -3374,20 +3374,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
@@ -5036,24 +5036,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image jobs-meteor
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'web 🛡 audit | dev '
-      optional: true
-    - job: 'web 👮 lint | dev '
-      optional: true
-    - job: 'web 🧪 test | dev '
-      optional: true
-    - job: 'web 🔨 app | dev '
-      optional: true
-    - job: 'web 🔨 docker | dev '
-      optional: true
     - job: 'web 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
@@ -1611,8 +1611,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
     - job: 'api 🛡 audit | dev '
       optional: true
     - job: 'api 👮 lint | dev '

--- a/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
@@ -1611,8 +1611,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
     - job: 'api 🛡 audit | dev '
       optional: true
     - job: 'api 👮 lint | dev '

--- a/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
@@ -9644,45 +9644,9 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'app1 🛡 audit | dev '
-      optional: true
-    - job: 'app1 👮 lint | dev '
-      optional: true
-    - job: 'app1 🧪 test | dev '
-      optional: true
-    - job: 'app1 🔨 app | dev '
-      optional: true
-    - job: 'app1 🔨 docker | dev '
-      optional: true
     - job: 'app1 🚀 Deploy | dev '
       optional: true
-    - job: 'app2 🛡 audit | dev '
-      optional: true
-    - job: 'app2 👮 lint | dev '
-      optional: true
-    - job: 'app2 🧪 test | dev '
-      optional: true
-    - job: 'app2 🔨 app | dev '
-      optional: true
-    - job: 'app2 🔨 docker | dev '
-      optional: true
     - job: 'app2 🚀 Deploy | dev '
-      optional: true
-    - job: 'kube 🛡 audit | dev '
-      optional: true
-    - job: 'kube 👮 lint | dev '
-      optional: true
-    - job: 'kube 🧪 test | dev '
-      optional: true
-    - job: 'kube 🔨 app | dev '
-      optional: true
-    - job: 'kube 🔨 docker | dev '
       optional: true
     - job: 'kube 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
@@ -4853,29 +4853,7 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'app 🛡 audit | dev '
-      optional: true
-    - job: 'app 👮 lint | dev '
-      optional: true
-    - job: 'app 🧪 test | dev '
-      optional: true
-    - job: 'app 🔨 app | dev '
-      optional: true
     - job: 'app 🚀 Deploy | dev '
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
       optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
@@ -3418,20 +3418,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
@@ -3446,20 +3446,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
@@ -3492,20 +3492,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'my-app 🛡 audit | dev '
-      optional: true
-    - job: 'my-app 👮 lint | dev '
-      optional: true
-    - job: 'my-app 🧪 test | dev '
-      optional: true
-    - job: 'my-app 🔨 app | dev '
-      optional: true
-    - job: 'my-app 🔨 docker | dev '
-      optional: true
     - job: 'my-app 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/pages-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pages-deploy.test.ts.snap
@@ -562,8 +562,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
     - job: 'docs 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
@@ -3440,20 +3440,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
@@ -3446,20 +3446,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
-    - job: 'www 🔨 docker | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
@@ -4523,23 +4523,7 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: '🔸 myWorkspace 🛡 audit | dev '
-      optional: true
-    - job: '🔸 myWorkspace 👮 lint | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🧪 test | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🔨 app | dev '
-      optional: true
-    - job: '🔹 api 🔨 docker | dev '
-      optional: true
     - job: '🔹 api 🚀 Deploy | dev '
-      optional: true
-    - job: '🔹 www 🔨 docker | dev '
       optional: true
     - job: '🔹 www 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/project-images.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/project-images.test.ts.snap
@@ -3285,18 +3285,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 image db-tools
-      optional: true
-    - job: 🐳 image java-build
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🔨 docker | dev '
-      optional: true
     - job: 'api 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker-dockerfile.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker-dockerfile.test.ts.snap
@@ -279,18 +279,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'app 🛡 audit | dev '
-      optional: true
-    - job: 'app 👮 lint | dev '
-      optional: true
-    - job: 'app 🧪 test | dev '
-      optional: true
-    - job: 'app 🔨 docker | dev '
-      optional: true
     - job: 'app 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
@@ -3627,18 +3627,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'app 🛡 audit | dev '
-      optional: true
-    - job: 'app 👮 lint | dev '
-      optional: true
-    - job: 'app 🧪 test | dev '
-      optional: true
-    - job: 'app 🔨 docker | dev '
-      optional: true
     - job: 'app 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
@@ -9009,45 +9009,9 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: 🐳 catladder image kubernetes
-      optional: true
-    - job: 'app1 🛡 audit | dev '
-      optional: true
-    - job: 'app1 👮 lint | dev '
-      optional: true
-    - job: 'app1 🧪 test | dev '
-      optional: true
-    - job: 'app1 🔨 app | dev '
-      optional: true
-    - job: 'app1 🔨 docker | dev '
-      optional: true
     - job: 'app1 🚀 Deploy | dev '
       optional: true
-    - job: 'app2 🛡 audit | dev '
-      optional: true
-    - job: 'app2 👮 lint | dev '
-      optional: true
-    - job: 'app2 🧪 test | dev '
-      optional: true
-    - job: 'app2 🔨 app | dev '
-      optional: true
-    - job: 'app2 🔨 docker | dev '
-      optional: true
     - job: 'app2 🚀 Deploy | dev '
-      optional: true
-    - job: 'app3 🛡 audit | dev '
-      optional: true
-    - job: 'app3 👮 lint | dev '
-      optional: true
-    - job: 'app3 🧪 test | dev '
-      optional: true
-    - job: 'app3 🔨 app | dev '
-      optional: true
-    - job: 'app3 🔨 docker | dev '
       optional: true
     - job: 'app3 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
@@ -3222,26 +3222,6 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 'api 🛡 audit | dev '
-      optional: true
-    - job: 'api 👮 lint | dev '
-      optional: true
-    - job: 'api 🧪 test | dev '
-      optional: true
-    - job: 'api 🔨 app | dev '
-      optional: true
-    - job: 'api 🚀 Deploy | dev '
-      optional: true
-    - job: 'www 🛡 audit | dev '
-      optional: true
-    - job: 'www 👮 lint | dev '
-      optional: true
-    - job: 'www 🧪 test | dev '
-      optional: true
-    - job: 'www 🔨 app | dev '
-      optional: true
     - job: 'www 🚀 Deploy | dev '
       optional: true
 ⚠️ force create release:

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
@@ -4559,23 +4559,7 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: '🔸 myWorkspace 🛡 audit | dev '
-      optional: true
-    - job: '🔸 myWorkspace 👮 lint | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🧪 test | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🔨 app | dev '
-      optional: true
-    - job: '🔹 api 🔨 docker | dev '
-      optional: true
     - job: '🔹 api 🚀 Deploy | dev '
-      optional: true
-    - job: '🔹 www 🔨 docker | dev '
       optional: true
     - job: '🔹 www 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
@@ -4539,23 +4539,7 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: '🔸 myWorkspace 🛡 audit | dev '
-      optional: true
-    - job: '🔸 myWorkspace 👮 lint | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🧪 test | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🔨 app | dev '
-      optional: true
-    - job: '🔹 api 🔨 docker | dev '
-      optional: true
     - job: '🔹 api 🚀 Deploy | dev '
-      optional: true
-    - job: '🔹 www 🔨 docker | dev '
       optional: true
     - job: '🔹 www 🚀 Deploy | dev '
       optional: true

--- a/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
@@ -4912,25 +4912,7 @@ create release:
     - job: create release
     - job: 🐳 catladder image semantic-release
       optional: true
-    - job: 🐳 catladder image jobs-default
-      optional: true
-    - job: 🐳 catladder image docker-build
-      optional: true
-    - job: '🔸 myWorkspace 🛡 audit | dev '
-      optional: true
-    - job: '🔸 myWorkspace 👮 lint | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🧪 test | dev '
-      optional: true
-    - job: '🔸 myWorkspace 🔨 app | dev '
-      optional: true
-    - job: '🔹 api 🔨 docker | dev '
-      optional: true
     - job: '🔹 api 🚀 Deploy | dev '
-      optional: true
-    - job: '🔹 www 🔨 docker | dev '
-      optional: true
-    - job: '🔹 www 🚀 Deploy | dev '
       optional: true
     - job: '🔹 www 🔍 verify | dev '
       optional: true

--- a/packages/pipeline/src/backends/gitlab/GitlabBackend.ts
+++ b/packages/pipeline/src/backends/gitlab/GitlabBackend.ts
@@ -174,15 +174,28 @@ export class GitlabBackend implements PipelineBackend {
     // runs automatically in a main-branch pipeline. Manual jobs (stop,
     // rollback, gates) are excluded — gitlab skips a job whose needs
     // include an unplayed manual job.
-    const mainBranchJobNames = [
-      ...new Set(
-        jobsPerTrigger
-          .filter(({ trigger }) => trigger === "mainBranch")
-          .flatMap(({ jobs }) => jobs)
-          .filter(({ gitlabJob }) => !isManualGitlabJob(gitlabJob))
-          .map(({ name }) => name),
+    const mainBranchAutoJobs = jobsPerTrigger
+      .filter(({ trigger }) => trigger === "mainBranch")
+      .flatMap(({ jobs }) => jobs)
+      .filter(({ gitlabJob }) => !isManualGitlabJob(gitlabJob));
+
+    // `needs:` is transitive: a job that another auto job needs is
+    // already awaited through that job, and a failed ancestor skips its
+    // descendants either way. The executor therefore only needs the
+    // SINKS of the auto-job graph (test/lint/audit and the deploy or
+    // verify tips) — everything upstream is implied. This keeps the
+    // executor's needs list far below gitlab's 50-entry cap even on
+    // pipelines with many components.
+    const neededByAnAutoJob = new Set(
+      mainBranchAutoJobs.flatMap(({ gitlabJob }) =>
+        (gitlabJob.needs ?? []).map((need) =>
+          typeof need === "string" ? need : need.job,
+        ),
       ),
-    ];
+    );
+    const mainBranchJobNames = [
+      ...new Set(mainBranchAutoJobs.map(({ name }) => name)),
+    ].filter((name) => !neededByAnAutoJob.has(name));
 
     const releaseJobs = getGitlabReleaseJobs(
       config,


### PR DESCRIPTION
maw's observation on the 50-needs fallback: the executor *"technically does not need to wait for all jobs in all stages, only verify (if any), deploy and test"* — correct, because `needs:` is transitive.

### Before / after

The queued-release executor (`🚀 release once pipeline succeeds`) expressed "run once everything is green" as a `needs:` on **every** automatic main-branch job. Needing a deploy already implies its docker build, app build and quality gates (they are in the deploy's own `needs`), and a failed ancestor skips its descendants — and with them the executor — either way. So the executor now needs only the **sinks** of the auto-job graph: deploy/verify tips plus terminal test/lint/audit jobs nothing else consumes.

Edge handled: a job needed *only by manual jobs* still counts as a sink (only needs **from auto jobs** are collected), so it keeps gating the release directly.

### Why it matters

GitLab caps `needs:` at 50 entries. food-2050's main pipeline just crossed 50 auto jobs and fell back to the legacy release button (playable only after the pipeline finishes). Its sink count is a fraction of the job count, so the click-any-time queueing comes back — and the cap is now a function of components-with-deploys rather than total jobs.

### Verification

Snapshot diff is **pure deletion: 469 `needs:` entries removed, 0 added** — the sinks were already present in every list; only their ancestors dropped out. Spot checks:

- `kubernetes-with-jobs`: executor needs the two deploys; each deploy carries test/lint/audit/app/docker in its own needs
- `cloud-run-verify`: executor needs the verify tip only

264/264 pass.