### PR TITLE
refactor(gitlab): extract the sink computation, pin its invariant

### DIFF
--- a/packages/pipeline/src/backends/gitlab/GitlabBackend.ts
+++ b/packages/pipeline/src/backends/gitlab/GitlabBackend.ts
@@ -26,6 +26,7 @@ import { createGitlabJobs } from "./createGitlabJobs";
 import { createGitlabPipelineWithDefaults } from "./createGitlabPipeline";
 import { getGitlabReleaseJobs } from "./gitlabReleaseJobs";
 import { getPipelineStages } from "./getPipelineStages";
+import { getReleaseGateJobNames } from "./releaseGateJobs";
 import { sortGitLabJobDefProps } from "./sortGitLabJobDefProps";
 import { GENERATED_FILE_MARKER } from "../../utils/writeFiles";
 
@@ -179,23 +180,9 @@ export class GitlabBackend implements PipelineBackend {
       .flatMap(({ jobs }) => jobs)
       .filter(({ gitlabJob }) => !isManualGitlabJob(gitlabJob));
 
-    // `needs:` is transitive: a job that another auto job needs is
-    // already awaited through that job, and a failed ancestor skips its
-    // descendants either way. The executor therefore only needs the
-    // SINKS of the auto-job graph (test/lint/audit and the deploy or
-    // verify tips) — everything upstream is implied. This keeps the
-    // executor's needs list far below gitlab's 50-entry cap even on
-    // pipelines with many components.
-    const neededByAnAutoJob = new Set(
-      mainBranchAutoJobs.flatMap(({ gitlabJob }) =>
-        (gitlabJob.needs ?? []).map((need) =>
-          typeof need === "string" ? need : need.job,
-        ),
-      ),
-    );
-    const mainBranchJobNames = [
-      ...new Set(mainBranchAutoJobs.map(({ name }) => name)),
-    ].filter((name) => !neededByAnAutoJob.has(name));
+    // only the sinks of the auto-job graph — every other auto job is
+    // awaited transitively through them (see releaseGateJobs.ts)
+    const mainBranchJobNames = getReleaseGateJobNames(mainBranchAutoJobs);
 
     const releaseJobs = getGitlabReleaseJobs(
       config,

--- a/packages/pipeline/src/backends/gitlab/__tests__/releaseGateJobs.test.ts
+++ b/packages/pipeline/src/backends/gitlab/__tests__/releaseGateJobs.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { getReleaseGateJobNames } from "../releaseGateJobs";
+
+type Job = {
+  name: string;
+  gitlabJob: { needs?: Array<string | { job: string }> };
+};
+
+const job = (name: string, needs: string[] = []): Job => ({
+  name,
+  gitlabJob: { needs: needs.map((n) => ({ job: n })) },
+});
+
+/**
+ * THE invariant (the reason the executor may need only the sinks):
+ * every automatic job must be awaited by the executor — either by being
+ * in its needs directly, or by being an ancestor of a job that is.
+ *
+ * This deliberately does NOT assert which jobs are in the result: the
+ * wiring (deploys needing tests, ...) may change; the property must not.
+ */
+const expectEveryAutoJobCovered = (autoJobs: Job[], gateNames: string[]) => {
+  const byName = new Map(autoJobs.map((j) => [j.name, j]));
+  // walk ancestors of the gate set: everything they (transitively) need
+  const covered = new Set<string>();
+  const queue = [...gateNames];
+  while (queue.length > 0) {
+    const name = queue.pop()!;
+    if (covered.has(name)) continue;
+    covered.add(name);
+    for (const need of byName.get(name)?.gitlabJob.needs ?? []) {
+      queue.push(typeof need === "string" ? need : need.job);
+    }
+  }
+  for (const { name } of autoJobs) {
+    expect(
+      covered,
+      `auto job "${name}" is not awaited by the executor`,
+    ).toContain(name);
+  }
+};
+
+describe("getReleaseGateJobNames", () => {
+  it("needs only the tips of a build → deploy → verify chain", () => {
+    const jobs = [
+      job("image"),
+      job("build", ["image"]),
+      job("test", ["build"]),
+      job("deploy", ["build", "test"]),
+      job("verify", ["deploy"]),
+    ];
+    const gates = getReleaseGateJobNames(jobs);
+    expect(gates).toEqual(["verify"]);
+    expectEveryAutoJobCovered(jobs, gates);
+  });
+
+  it("keeps terminal quality jobs that nothing consumes", () => {
+    const jobs = [
+      job("build"),
+      job("deploy", ["build"]),
+      job("lint"),
+      job("audit"),
+    ];
+    const gates = getReleaseGateJobNames(jobs);
+    expect(gates.sort()).toEqual(["audit", "deploy", "lint"]);
+    expectEveryAutoJobCovered(jobs, gates);
+  });
+
+  it("re-includes test automatically if deploys ever stop needing it", () => {
+    // the "what if we change things around" case: deploy decoupled from
+    // test ("deploy fast, test in parallel"). test loses its consumer,
+    // becomes a sink, and re-enters the executor's needs BY ITSELF —
+    // no explicit test-stage entry required.
+    const coupled = [job("test"), job("deploy", ["test"])];
+    expect(getReleaseGateJobNames(coupled)).toEqual(["deploy"]);
+
+    const decoupled = [job("test"), job("deploy")];
+    expect(getReleaseGateJobNames(decoupled).sort()).toEqual([
+      "deploy",
+      "test",
+    ]);
+    expectEveryAutoJobCovered(decoupled, getReleaseGateJobNames(decoupled));
+  });
+
+  it("treats a job consumed only by MANUAL jobs as a sink", () => {
+    // the manual deploy is not in the auto set at all — its needs must
+    // not hide the build from the executor, or a red build could no
+    // longer block the release
+    const autoJobs = [job("build"), job("test", ["build"])];
+    // (a manual "deploy" needing "test" exists but is excluded upstream)
+    const gates = getReleaseGateJobNames(autoJobs);
+    expect(gates).toEqual(["test"]);
+    expectEveryAutoJobCovered(autoJobs, gates);
+  });
+
+  it("supports plain-string needs entries", () => {
+    const jobs = [
+      { name: "a", gitlabJob: { needs: [] } },
+      { name: "b", gitlabJob: { needs: ["a"] } },
+    ];
+    expect(getReleaseGateJobNames(jobs)).toEqual(["b"]);
+  });
+
+  it("covers diamonds without duplicating the tip", () => {
+    const jobs = [
+      job("build"),
+      job("deploy-a", ["build"]),
+      job("deploy-b", ["build"]),
+      job("verify", ["deploy-a", "deploy-b"]),
+    ];
+    const gates = getReleaseGateJobNames(jobs);
+    expect(gates).toEqual(["verify"]);
+    expectEveryAutoJobCovered(jobs, gates);
+  });
+});

--- a/packages/pipeline/src/backends/gitlab/releaseGateJobs.ts
+++ b/packages/pipeline/src/backends/gitlab/releaseGateJobs.ts
@@ -1,0 +1,36 @@
+import type { GitlabJobDef } from "../../types";
+
+/**
+ * the jobs the queued-release executor must `needs:` so that it runs
+ * exactly when the whole main-branch pipeline succeeded.
+ *
+ * `needs:` is transitive: a job that another automatic job needs is
+ * already awaited through that job, and a failed ancestor skips its
+ * descendants (and with them the executor) either way. The executor
+ * therefore only needs the SINKS of the auto-job graph — the jobs no
+ * other automatic job depends on (deploy/verify tips, terminal
+ * test/lint/audit). This keeps the needs list far below gitlab's
+ * 50-entry cap even on pipelines with many components.
+ *
+ * INVARIANT (do not weaken): every automatic job is an ancestor of the
+ * returned set. This holds for ANY graph shape, because the sinks are
+ * recomputed from the actual needs edges on every generation — if e.g.
+ * deploys ever stop needing the test jobs, the test jobs become sinks
+ * and re-enter the executor's needs by themselves. Only needs FROM
+ * automatic jobs count: a job consumed solely by manual jobs is a sink
+ * too, and keeps gating the release directly.
+ */
+export const getReleaseGateJobNames = (
+  autoJobs: Array<{ name: string; gitlabJob: Pick<GitlabJobDef, "needs"> }>,
+): string[] => {
+  const neededByAnAutoJob = new Set(
+    autoJobs.flatMap(({ gitlabJob }) =>
+      (gitlabJob.needs ?? []).map((need) =>
+        typeof need === "string" ? need : need.job,
+      ),
+    ),
+  );
+  return [...new Set(autoJobs.map(({ name }) => name))].filter(
+    (name) => !neededByAnAutoJob.has(name),
+  );
+};


### PR DESCRIPTION
Follow-up to #7 — this commit was pushed seconds after the merge, so reopening it as its own PR (plus a prettier fix the late push carried).

`getReleaseGateJobNames` moves to its own module so it can be unit-tested. The tests deliberately do **not** pin which jobs end up in the executor's needs — that's wiring, and it may change. They pin the **property**: `expectEveryAutoJobCovered` walks the ancestors of the returned set and asserts every automatic job is awaited, directly or transitively.

Includes the case maw asked about: if deploys ever stop needing the test jobs ("deploy fast, test in parallel"), test loses its consumer, becomes a sink, and re-enters the executor's needs by itself — now proven by a test rather than promised in a comment. Plus: terminal quality jobs, manual-only consumers, string-shaped needs entries, diamonds.

No generated-output change: pure extraction + tests. 270/270 pass (6 new).