### PR TITLE
feat(github): generated `catladder ✅` aggregate job for branch protection

### DIFF
--- a/.changeset/minor-github-aggregate-check.md
+++ b/.changeset/minor-github-aggregate-check.md
@@ -1,0 +1,5 @@
+---
+"catladder": minor
+---
+
+The github review workflow gains a generated **`catladder ✅`** job that succeeds exactly when every other review job succeeded (`needs:` all of them, `if: always()`, skipped counts as failed; `continue-on-error` jobs like the audit stay non-blocking). It exists to be the **one required status check** in branch protection: requiring real job names goes stale on every component change — a renamed required job blocks its own PR forever, a new component's jobs are silently not required — while this context never changes. Combined with the repo's "Allow auto-merge" setting this restores gitlab's built-in "merge when pipeline succeeds" on github.

--- a/.github/workflows/catladder-review.yml
+++ b/.github/workflows/catladder-review.yml
@@ -372,3 +372,26 @@ jobs:
       - name: changeset check
         run: changesetCheck
         shell: bash
+  catladder-ok:
+    name: catladder ✅
+    runs-on: ubuntu-latest
+    needs:
+      - catladder-image-changesets
+      - catladder-image-jobs-default
+      - catladder-image-npm-publish
+      - changeset-check
+      - cli-deploy-review
+      - ws-base-app-review
+      - ws-base-audit-review
+      - ws-base-lint-review
+      - ws-base-test-review
+    if: always()
+    steps:
+      - name: catladder ✅
+        run: |-
+          results='${{ toJSON(needs) }}'
+          echo "$results"
+          if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+            echo "a required job did not succeed"; exit 1
+          fi
+        shell: bash

--- a/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
@@ -861,6 +861,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/changesets-releases-auto.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/changesets-releases-auto.test.ts.snap
@@ -894,6 +894,30 @@ catladder-review.yml:
         - name: changeset check
           run: changesetCheck
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-changesets
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - changeset-check
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
@@ -915,6 +915,30 @@ catladder-review.yml:
         - name: changeset check
           run: changesetCheck
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-changesets
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - changeset-check
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/app-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - app-app-review
+        - app-audit-review
+        - app-deploy-review
+        - app-docker-review
+        - app-lint-review
+        - app-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-existing-image.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-existing-image.test.ts.snap
@@ -308,6 +308,22 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-semantic-release
+        - www-deploy-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-llama.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-llama.test.ts.snap
@@ -310,6 +310,22 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/llm-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-semantic-release
+        - llm-deploy-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
@@ -988,6 +988,30 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/web-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-jobs-meteor
+        - catladder-image-semantic-release
+        - web-app-review
+        - web-audit-review
+        - web-deploy-review
+        - web-docker-review
+        - web-lint-review
+        - web-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-n8n.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-n8n.test.ts.snap
@@ -312,6 +312,22 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/n8n-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-semantic-release
+        - n8n-deploy-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
@@ -894,6 +894,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-storybook.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-storybook.test.ts.snap
@@ -678,6 +678,26 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-deploy-review
+        - api-docker-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
@@ -1372,6 +1372,36 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-verify-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - api-verify-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - db-app-review
+        - db-audit-review
+        - db-deploy-review
+        - db-docker-review
+        - db-lint-review
+        - db-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
@@ -894,6 +894,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
@@ -894,6 +894,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
@@ -1742,6 +1742,41 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - db1-app-review
+        - db1-audit-review
+        - db1-deploy-review
+        - db1-docker-review
+        - db1-lint-review
+        - db1-test-review
+        - db2-app-review
+        - db2-audit-review
+        - db2-deploy-review
+        - db2-docker-review
+        - db2-lint-review
+        - db2-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
@@ -1320,6 +1320,35 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/worker-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - worker-app-review
+        - worker-audit-review
+        - worker-deploy-review
+        - worker-docker-review
+        - worker-lint-review
+        - worker-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
@@ -894,6 +894,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
@@ -656,6 +656,28 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/custom-build-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-build-job.test.ts.snap
@@ -522,6 +522,25 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-deploy-review
+        - www-docker-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
@@ -890,6 +890,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
@@ -872,6 +872,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
@@ -912,6 +912,26 @@ catladder-review.yml:
               api/dist
             if-no-files-found: warn
             include-hidden-files: true
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
@@ -940,6 +940,30 @@ catladder-review.yml:
               cypress/videos
             if-no-files-found: warn
             include-hidden-files: true
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-e2e-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/app-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - app-app-review
+        - app-audit-review
+        - app-deploy-review
+        - app-docker-review
+        - app-lint-review
+        - app-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
@@ -964,6 +964,30 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
@@ -1008,6 +1008,30 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
@@ -1356,6 +1356,36 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
@@ -1008,6 +1008,30 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
@@ -1104,6 +1104,31 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/web-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-jobs-meteor
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+        - web-app-review
+        - web-audit-review
+        - web-deploy-review
+        - web-docker-review
+        - web-lint-review
+        - web-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
@@ -642,6 +642,26 @@ catladder-review.yml:
               api/dist
             if-no-files-found: warn
             include-hidden-files: true
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
@@ -642,6 +642,26 @@ catladder-review.yml:
               api/dist
             if-no-files-found: warn
             include-hidden-files: true
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
@@ -1784,6 +1784,42 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/kube-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - app1-app-review
+        - app1-audit-review
+        - app1-deploy-review
+        - app1-docker-review
+        - app1-lint-review
+        - app1-test-review
+        - app2-app-review
+        - app2-audit-review
+        - app2-deploy-review
+        - app2-docker-review
+        - app2-lint-review
+        - app2-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+        - kube-app-review
+        - kube-audit-review
+        - kube-deploy-review
+        - kube-docker-review
+        - kube-lint-review
+        - kube-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
@@ -1282,6 +1282,34 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-docker-review
+        - api-lint-review
+        - api-test-review
+        - app-app-review
+        - app-audit-review
+        - app-deploy-review
+        - app-lint-review
+        - app-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
@@ -872,6 +872,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
@@ -814,6 +814,28 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/lib-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+        - catladder-image-npm-publish
+        - catladder-image-semantic-release
+        - lib-app-review
+        - lib-audit-review
+        - lib-deploy-review
+        - lib-lint-review
+        - lib-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
@@ -900,6 +900,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/my-app-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - my-app-app-review
+        - my-app-audit-review
+        - my-app-deploy-review
+        - my-app-docker-review
+        - my-app-lint-review
+        - my-app-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
@@ -883,6 +883,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
@@ -882,6 +882,29 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
@@ -980,6 +980,31 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-deploy-review
+        - api-docker-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - ws-myworkspace-app-review
+        - ws-myworkspace-audit-review
+        - ws-myworkspace-lint-review
+        - ws-myworkspace-test-review
+        - www-deploy-review
+        - www-docker-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/project-images.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/project-images.test.ts.snap
@@ -778,6 +778,28 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/api-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-deploy-review
+        - api-docker-review
+        - api-test-review
+        - catladder-image-docker-build
+        - catladder-image-semantic-release
+        - image-db-tools
+        - image-java-build
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
@@ -716,6 +716,28 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/app-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - app-audit-review
+        - app-deploy-review
+        - app-docker-review
+        - app-lint-review
+        - app-test-review
+        - catladder-image-docker-build
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
@@ -1824,6 +1824,42 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/app3-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - app1-app-review
+        - app1-audit-review
+        - app1-deploy-review
+        - app1-docker-review
+        - app1-lint-review
+        - app1-test-review
+        - app2-app-review
+        - app2-audit-review
+        - app2-deploy-review
+        - app2-docker-review
+        - app2-lint-review
+        - app2-test-review
+        - app3-app-review
+        - app3-audit-review
+        - app3-deploy-review
+        - app3-docker-review
+        - app3-lint-review
+        - app3-test-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-kubernetes
+        - catladder-image-semantic-release
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
@@ -1034,6 +1034,32 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-app-review
+        - api-audit-review
+        - api-deploy-review
+        - api-lint-review
+        - api-test-review
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
@@ -998,6 +998,31 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-deploy-review
+        - api-docker-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - ws-myworkspace-app-review
+        - ws-myworkspace-audit-review
+        - ws-myworkspace-lint-review
+        - ws-myworkspace-test-review
+        - www-deploy-review
+        - www-docker-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
@@ -992,6 +992,31 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-deploy-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-deploy-review
+        - api-docker-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - ws-myworkspace-app-review
+        - ws-myworkspace-audit-review
+        - ws-myworkspace-lint-review
+        - ws-myworkspace-test-review
+        - www-deploy-review
+        - www-docker-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
@@ -1058,6 +1058,32 @@ catladder-review.yml:
           id: main
           run: bash .catladder-generated/github/scripts/www-verify-review.sh
           shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - api-deploy-review
+        - api-docker-review
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - ws-myworkspace-app-review
+        - ws-myworkspace-audit-review
+        - ws-myworkspace-lint-review
+        - ws-myworkspace-test-review
+        - www-deploy-review
+        - www-docker-review
+        - www-verify-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
 catladder-release.yml:
   name: 🛠️ catladder release
   on:

--- a/packages/pipeline/src/backends/github/GithubBackend.ts
+++ b/packages/pipeline/src/backends/github/GithubBackend.ts
@@ -15,6 +15,7 @@ import {
 } from "./createGithubJobs";
 import { JobImagesPlan } from "../../customImages/jobImagesPlan";
 import { makeEnsureImageGithubJobs } from "./ensureImageJobs";
+import { makeAggregateCheckJob } from "./aggregateCheckJob";
 import { getCatciGeneratedFiles } from "../../catci/shippedCatci";
 import {
   getGithubCreateReleaseWorkflow,
@@ -285,11 +286,22 @@ export class GithubBackend implements PipelineBackend {
       }
 
       if (Object.keys(jobs).length > 0) {
+        const workflowJobs = { ...makeEnsureImageGithubJobs(images), ...jobs };
         workflows[`${GENERATED_FILE_PREFIX}${workflowFileName(trigger)}`] = {
           ...TRIGGER_WORKFLOWS[trigger],
           ...workflowPermissions(images),
           env: workflowEnv,
-          jobs: { ...makeEnsureImageGithubJobs(images), ...jobs },
+          // the review workflow additionally gets the aggregate job —
+          // the one stable required-status context for branch
+          // protection. Requiring real job names instead goes stale on
+          // every component change: a renamed required job blocks its
+          // own PR forever, a new component's jobs are silently not
+          // required. Added at finalization so its needs cover the
+          // image-build jobs too.
+          jobs:
+            trigger === "mr"
+              ? { ...workflowJobs, ...makeAggregateCheckJob(workflowJobs) }
+              : workflowJobs,
         };
       }
     }

--- a/packages/pipeline/src/backends/github/aggregateCheckJob.ts
+++ b/packages/pipeline/src/backends/github/aggregateCheckJob.ts
@@ -1,0 +1,52 @@
+import type { GithubJob } from "../../types/github-types";
+
+export const AGGREGATE_CHECK_JOB_ID = "catladder-ok";
+export const AGGREGATE_CHECK_JOB_NAME = "catladder ✅";
+
+/**
+ * one job that succeeds exactly when every other job of the review
+ * workflow succeeded — the single, STABLE required-status context for
+ * branch protection.
+ *
+ * Requiring the real job names instead goes stale on every component
+ * change: a renamed required job never reports on the very PR that
+ * renames it ("Expected — waiting for status", unmergeable), and a new
+ * component's jobs are silently not required at all. This job's `needs`
+ * are regenerated with the workflow, so protection stays correct with
+ * a single one-time setup.
+ *
+ * Semantics:
+ * - `if: always()` — the job must run (and fail) when an ancestor
+ *   failed; without it a failed need would leave it skipped, and a
+ *   skipped required check blocks the merge with no explanation.
+ * - a skipped need counts as failure: review jobs are unconditional,
+ *   so skipped always means "an ancestor failed".
+ * - `continue-on-error` jobs (security audit, changeset check) report
+ *   `success` to `needs` even when red, so they stay non-blocking here
+ *   by the same mechanism that keeps their workflow green.
+ */
+export const makeAggregateCheckJob = (
+  reviewJobs: Record<string, GithubJob>,
+): Record<string, GithubJob> => ({
+  [AGGREGATE_CHECK_JOB_ID]: {
+    name: AGGREGATE_CHECK_JOB_NAME,
+    "runs-on": "ubuntu-latest",
+    needs: Object.keys(reviewJobs).sort(),
+    if: "always()",
+    steps: [
+      {
+        name: AGGREGATE_CHECK_JOB_NAME,
+        // the needs context only interpolates inside the workflow file,
+        // so this script stays inline
+        run: [
+          `results='\${{ toJSON(needs) }}'`,
+          `echo "$results"`,
+          `if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then`,
+          `  echo "a required job did not succeed"; exit 1`,
+          `fi`,
+        ].join("\n"),
+        shell: "bash",
+      },
+    ],
+  },
+});

--- a/skills/catladder-migrate-ci-backend/SKILL.md
+++ b/skills/catladder-migrate-ci-backend/SKILL.md
@@ -255,6 +255,21 @@ now-wrong `gitRemote`, regenerate once more, and finish with
 
 ## After the cut-over
 
+- **Set up merge gating — GitHub has none by default.** On GitLab,
+  "merge when pipeline succeeds" is built in; on a fresh GitHub repo a
+  PR is mergeable the moment it opens, checks still running, and the
+  auto-merge button does not even appear. Two one-time settings fix it:
+  1. Settings → General → Pull Requests → enable **"Allow auto-merge"**
+     (and "Automatically delete head branches" while there)
+  2. a branch protection rule on the default branch requiring the
+     **`catladder ✅`** status check — the aggregate job catladder
+     generates into the review workflow precisely for this. Require
+     only this one context, never individual job names: those change
+     with every component add/rename, and a stale required name blocks
+     the renaming PR forever ("Expected — waiting for status").
+  Consider leaving "enforce for administrators" off: this repo's CI is
+  generated, so if generation itself ever breaks, the admin bypass is
+  what lets the fix merge.
 - Tell the team where the pipeline lives now and how manual actions
   work there (on GitHub, manual jobs are dispatch workflows in the
   Actions sidebar — `🚀 catladder create release`, `▶️ catladder deploy`,


### PR DESCRIPTION
Implements the design from #9 (the part that makes protection maintenance-free).

### What

The review workflow gains one generated job, **`catladder ✅`**, that `needs:` every other job — image builds included, it's assembled at workflow finalization where they're known — with `if: always()`, failing unless every `needs.*.result` is `success`.

### Why

It is the single **stable** required-status context for branch protection. Requiring real job names (what our repo has today) goes stale in both directions:

- **add a component** → its jobs are not required → a red deploy on the very PR that introduces it doesn't block the merge
- **rename one** → the required name never reports on that PR → "Expected — waiting for status", unmergeable until an admin edits the rule

The aggregate's `needs` regenerate with the workflow, per branch — so a new component's jobs join it automatically *in the PR that adds them*, and renames can't strand anything.

### Semantics

- skipped counts as **failure**: review jobs are unconditional, so skipped always means an ancestor failed
- `continue-on-error` jobs (security audit, changeset check) report `success` to `needs` even when red — non-blocking here by the same mechanism that keeps the workflow green
- an example with no review jobs gets no aggregate (and no review workflow at all — first attempt had it conjuring a workflow containing only itself, caught by the pages-deploy snapshot)

### After merging

I'll repoint the `next`/`main` protection rules from the four named checks to this one context. The migration skill's after-cut-over section now documents the full github merge-gating setup (auto-merge toggle + this check), since gitlab ships that behavior built-in and a fresh github repo has none of it.

264/264 pass; gitlab output untouched.