### PR TITLE
feat(cli): project setup configures github merge gating, doctor verifies

### DIFF
--- a/.changeset/minor-setup-github-merge-gating.md
+++ b/.changeset/minor-setup-github-merge-gating.md
@@ -1,0 +1,5 @@
+---
+"catladder": minor
+---
+
+`project setup` now configures github merge gating, and `project doctor` verifies it. A fresh github repository lets PRs merge while checks are still running and never shows the auto-merge button — gitlab ships this behavior built-in. Setup enables auto-merge (+ delete-merged-branches) and adds a branch protection rule on the default branch requiring the generated `catladder ✅` check, merging non-destructively into any existing protection. Admins can still bypass per PR. On github-only projects, setup now also skips the gitlab-specific provisioning (access token, agent webhooks) instead of failing.

--- a/.claude/skills/catladder-migrate-ci-backend/SKILL.md
+++ b/.claude/skills/catladder-migrate-ci-backend/SKILL.md
@@ -257,6 +257,18 @@ now-wrong `gitRemote`, regenerate once more, and finish with
 
 ## After the cut-over
 
+- **Set up merge gating — GitHub has none by default.** On GitLab,
+  "merge when pipeline succeeds" is built in; on a fresh GitHub repo a
+  PR is mergeable the moment it opens, checks still running, and the
+  auto-merge button does not even appear. `yarn catladder project setup`
+  configures it: auto-merge + delete-merged-branches on the repo, and a
+  branch protection rule on the default branch requiring the generated
+  **`catladder ✅`** aggregate check (the one stable context — never
+  require individual job names, they change with every component
+  add/rename and a stale required name blocks its own PR forever).
+  `project doctor` verifies it. Two things stay human choices: "Do not
+  allow bypassing" (leave it off — generated CI means a generation bug
+  can only be fixed via the admin bypass) and required reviews.
 - Tell the team where the pipeline lives now and how manual actions
   work there (on GitHub, manual jobs are dispatch workflows in the
   Actions sidebar — `🚀 catladder create release`, `▶️ catladder deploy`,

--- a/apps/cli/src/apps/cli/commands/project/doctor/checkGithub.ts
+++ b/apps/cli/src/apps/cli/commands/project/doctor/checkGithub.ts
@@ -1,5 +1,6 @@
 import type { Config } from "@catladder/pipeline";
 import {
+  AGGREGATE_CHECK_JOB_NAME,
   getEnabledPipelineTypes,
   getPipelineGitRemote,
 } from "@catladder/pipeline";
@@ -9,6 +10,7 @@ import {
 } from "../../../../../commands/project/commandSecretsSyncGithub";
 import { mapWithConcurrency } from "../../../../../utils/concurrency";
 import {
+  ghApiJson,
   isGhAuthenticated,
   listGithubEnvironments,
   listGithubSecretNames,
@@ -152,5 +154,58 @@ export const checkGithub = async (report: DoctorReport, config: Config) => {
         `repo level: all ${repoLevelReferenced.length} referenced secrets/variables present`,
       );
     }
+  }
+
+  await checkGithubMergeGating(report, repo);
+};
+
+/**
+ * verifies the merge gating `project setup` configures: auto-merge
+ * enabled and the generated `catladder ✅` aggregate check required on
+ * the default branch. Without it a PR is mergeable while its checks
+ * are still running — gitlab ships this behavior built-in, github
+ * silently does not.
+ */
+const checkGithubMergeGating = async (report: DoctorReport, repo: string) => {
+  let repoInfo: { default_branch: string; allow_auto_merge: boolean };
+  try {
+    repoInfo = await ghApiJson("GET", `repos/${repo}`);
+  } catch (e) {
+    report.warn(`could not read repo settings of ${repo} (${e.message})`);
+    return;
+  }
+  if (repoInfo.allow_auto_merge) {
+    report.ok("auto-merge enabled");
+  } else {
+    report.fail(
+      "auto-merge disabled — the merge-when-pipeline-succeeds button cannot appear",
+      "run: catladder project setup",
+    );
+  }
+
+  const branch = repoInfo.default_branch;
+  const protection = await ghApiJson<any>(
+    "GET",
+    `repos/${repo}/branches/${branch}/protection`,
+  ).catch(() => null);
+  const checks: Array<{ context: string }> =
+    protection?.required_status_checks?.checks ?? [];
+  if (checks.some((c) => c.context === AGGREGATE_CHECK_JOB_NAME)) {
+    report.ok(`'${AGGREGATE_CHECK_JOB_NAME}' required on ${branch}`);
+  } else {
+    report.fail(
+      `'${AGGREGATE_CHECK_JOB_NAME}' is not a required check on ${branch} — PRs can merge while the pipeline is red or still running`,
+      "run: catladder project setup",
+    );
+  }
+  const stale = checks.filter((c) => c.context !== AGGREGATE_CHECK_JOB_NAME);
+  if (stale.length > 0) {
+    report.warn(
+      `${branch} requires ${stale.length} additional named check(s) (${stale
+        .map((c) => c.context)
+        .join(
+          ", ",
+        )}) — job names change with components; prefer only '${AGGREGATE_CHECK_JOB_NAME}'`,
+    );
   }
 };

--- a/apps/cli/src/apps/cli/commands/project/setup/index.ts
+++ b/apps/cli/src/apps/cli/commands/project/setup/index.ts
@@ -1,4 +1,8 @@
-import { createCatenvContext, generateAgentSkills } from "@catladder/pipeline";
+import {
+  createCatenvContext,
+  generateAgentSkills,
+  getEnabledPipelineTypes,
+} from "@catladder/pipeline";
 import type { IO } from "../../../../../core/types";
 import {
   getAllPipelineContexts,
@@ -8,6 +12,7 @@ import { setupAccessTokens } from "./setupAccessTokens";
 import { setupContext } from "./setupContext";
 import { setupTopic } from "./setupTopic";
 import { setupAgents } from "./setupAgents";
+import { setupGithub } from "./setupGithub";
 import { logSection } from "./logSection";
 import { ensureGcloudProjectNumbers } from "./ensureGcloudProjectNumbers";
 
@@ -33,17 +38,25 @@ export const setupProject = async (
     instance.log(` - ${context.name}:${context.env}`);
   });
 
+  const enabledPipelines = config ? getEnabledPipelineTypes(config) : [];
   await logSection(instance, "base setup", async () => {
-    await setupAccessTokens(instance);
+    // gitlab-specific provisioning (access token, agent webhooks) —
+    // meaningless (and failing) on a github-only project
+    if (enabledPipelines.includes("gitlab")) {
+      await setupAccessTokens(instance);
+      await setupAgents(instance);
+    }
     await setupTopic(instance);
-    await setupAgents(instance);
+    if (config) {
+      await setupGithub(instance, config);
+    }
   });
   for (const context of allContext) {
     await setupContext(instance, context);
   }
 
   instance.log("");
-  instance.log("gitlab is ready! 🥂");
+  instance.log(`${enabledPipelines.join(" + ") || "gitlab"} is ready! 🥂`);
   instance.log("\n");
   instance.log("do not forget to make sure that:");
   [

--- a/apps/cli/src/apps/cli/commands/project/setup/setupGithub.ts
+++ b/apps/cli/src/apps/cli/commands/project/setup/setupGithub.ts
@@ -1,0 +1,117 @@
+import type { Config } from "@catladder/pipeline";
+import {
+  AGGREGATE_CHECK_JOB_NAME,
+  getEnabledPipelineTypes,
+  getPipelineGitRemote,
+} from "@catladder/pipeline";
+import { getConfiguredGithubRepo } from "../../../../../commands/project/commandSecretsSyncGithub";
+import type { IO } from "../../../../../core/types";
+import { ghApiJson, isGhAuthenticated } from "../../../../../utils/github";
+
+/**
+ * configures github merge gating — the sane default gitlab ships
+ * built-in and a fresh github repository lacks entirely: without it a
+ * PR is mergeable the moment it opens, checks still running, and the
+ * auto-merge button never appears.
+ *
+ * - repo settings: allow auto-merge, delete merged head branches
+ * - branch protection on the default branch: require the generated
+ *   `catladder ✅` aggregate check (the one stable context — individual
+ *   job names change with every component add/rename)
+ *
+ * Deliberately non-destructive: existing protection settings
+ * (enforce-admins, required reviews, restrictions, strictness) are
+ * preserved; the aggregate context is merged into the required checks
+ * rather than replacing them. Admins can still bypass per PR — this is
+ * a default, not a cage.
+ */
+export const setupGithub = async (instance: IO, config: Config) => {
+  if (!getEnabledPipelineTypes(config).includes("github")) {
+    return;
+  }
+  if (!(await isGhAuthenticated())) {
+    instance.log(
+      "⚠️ github cli (gh) not authenticated — skipping github merge-gating setup (run: gh auth login)",
+    );
+    return;
+  }
+  const repo = await getConfiguredGithubRepo();
+  if (!repo) {
+    instance.log(
+      `⚠️ no github repository found on the '${getPipelineGitRemote(config, "github")}' remote — skipping github merge-gating setup`,
+    );
+    return;
+  }
+
+  const repoInfo = await ghApiJson<{
+    default_branch: string;
+    allow_auto_merge: boolean;
+    delete_branch_on_merge: boolean;
+  }>("GET", `repos/${repo}`);
+
+  if (!repoInfo.allow_auto_merge || !repoInfo.delete_branch_on_merge) {
+    await ghApiJson("PATCH", `repos/${repo}`, {
+      allow_auto_merge: true,
+      delete_branch_on_merge: true,
+    });
+    instance.log("✅ auto-merge + delete-merged-branches enabled");
+  } else {
+    instance.log("✅ auto-merge already enabled");
+  }
+
+  const branch = repoInfo.default_branch;
+  const protection = await ghApiJson<any>(
+    "GET",
+    `repos/${repo}/branches/${branch}/protection`,
+  ).catch(() => null); // 404: branch not protected yet
+
+  const existingChecks: Array<{ context: string; app_id?: number }> =
+    protection?.required_status_checks?.checks ?? [];
+  if (existingChecks.some((c) => c.context === AGGREGATE_CHECK_JOB_NAME)) {
+    instance.log(
+      `✅ '${AGGREGATE_CHECK_JOB_NAME}' already required on ${branch}`,
+    );
+    return;
+  }
+
+  // merge into whatever protection exists; PUT replaces the whole rule,
+  // so every preserved setting must be carried over explicitly
+  await ghApiJson("PUT", `repos/${repo}/branches/${branch}/protection`, {
+    required_status_checks: {
+      strict: protection?.required_status_checks?.strict ?? false,
+      checks: [
+        ...existingChecks.map(({ context, app_id }) => ({
+          context,
+          ...(app_id !== undefined ? { app_id } : {}),
+        })),
+        { context: AGGREGATE_CHECK_JOB_NAME },
+      ],
+    },
+    enforce_admins: protection?.enforce_admins?.enabled ?? false,
+    required_pull_request_reviews: protection?.required_pull_request_reviews
+      ? {
+          required_approving_review_count:
+            protection.required_pull_request_reviews
+              .required_approving_review_count ?? 0,
+          dismiss_stale_reviews:
+            protection.required_pull_request_reviews.dismiss_stale_reviews ??
+            false,
+          require_code_owner_reviews:
+            protection.required_pull_request_reviews
+              .require_code_owner_reviews ?? false,
+        }
+      : null,
+    restrictions: protection?.restrictions
+      ? {
+          users: protection.restrictions.users.map((u: any) => u.login),
+          teams: protection.restrictions.teams.map((t: any) => t.slug),
+          apps: protection.restrictions.apps.map((a: any) => a.slug),
+        }
+      : null,
+    allow_force_pushes: protection?.allow_force_pushes?.enabled ?? false,
+    allow_deletions: protection?.allow_deletions?.enabled ?? false,
+  });
+  instance.log(
+    `✅ branch protection on ${branch}: '${AGGREGATE_CHECK_JOB_NAME}' required (merges now wait for the pipeline)`,
+  );
+};

--- a/apps/cli/src/utils/github.ts
+++ b/apps/cli/src/utils/github.ts
@@ -167,3 +167,33 @@ export const ensureGithubEnvironment = async (
           ),
     );
   });
+
+/** runs `gh api` with an optional JSON body and returns the parsed response */
+export const ghApiJson = async <T = any>(
+  method: "GET" | "PATCH" | "PUT",
+  path: string,
+  body?: unknown,
+): Promise<T> => {
+  const args = ["api", "-X", method, path];
+  const child = spawn("gh", [...args, ...(body ? ["--input", "-"] : [])], {
+    stdio: [body ? "pipe" : "ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout?.on("data", (data) => (stdout += data));
+  child.stderr?.on("data", (data) => (stderr += data));
+  if (body) {
+    child.stdin?.write(JSON.stringify(body));
+    child.stdin?.end();
+  }
+  return new Promise<T>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) =>
+      code === 0
+        ? resolve(stdout ? JSON.parse(stdout) : (undefined as T))
+        : reject(
+            new Error(`gh api ${method} ${path} failed: ${stderr.trim()}`),
+          ),
+    );
+  });
+};

--- a/packages/pipeline/src/backends/github/index.ts
+++ b/packages/pipeline/src/backends/github/index.ts
@@ -1,3 +1,4 @@
 export * from "./GithubBackend";
 export * from "./ciVariables";
 export * from "./scriptFiles";
+export * from "./aggregateCheckJob";

--- a/skills/catladder-migrate-ci-backend/SKILL.md
+++ b/skills/catladder-migrate-ci-backend/SKILL.md
@@ -258,18 +258,15 @@ now-wrong `gitRemote`, regenerate once more, and finish with
 - **Set up merge gating — GitHub has none by default.** On GitLab,
   "merge when pipeline succeeds" is built in; on a fresh GitHub repo a
   PR is mergeable the moment it opens, checks still running, and the
-  auto-merge button does not even appear. Two one-time settings fix it:
-  1. Settings → General → Pull Requests → enable **"Allow auto-merge"**
-     (and "Automatically delete head branches" while there)
-  2. a branch protection rule on the default branch requiring the
-     **`catladder ✅`** status check — the aggregate job catladder
-     generates into the review workflow precisely for this. Require
-     only this one context, never individual job names: those change
-     with every component add/rename, and a stale required name blocks
-     the renaming PR forever ("Expected — waiting for status").
-  Consider leaving "enforce for administrators" off: this repo's CI is
-  generated, so if generation itself ever breaks, the admin bypass is
-  what lets the fix merge.
+  auto-merge button does not even appear. `yarn catladder project setup`
+  configures it: auto-merge + delete-merged-branches on the repo, and a
+  branch protection rule on the default branch requiring the generated
+  **`catladder ✅`** aggregate check (the one stable context — never
+  require individual job names, they change with every component
+  add/rename and a stale required name blocks its own PR forever).
+  `project doctor` verifies it. Two things stay human choices: "Do not
+  allow bypassing" (leave it off — generated CI means a generation bug
+  can only be fixed via the admin bypass) and required reviews.
 - Tell the team where the pipeline lives now and how manual actions
   work there (on GitHub, manual jobs are dispatch workflows in the
   Actions sidebar — `🚀 catladder create release`, `▶️ catladder deploy`,


### PR DESCRIPTION
Closes #9.

maw: *"i have to set `catladder ✅` manually … for each project? its a sane default to have. you can still overrule it in each mr to bypass the checks."*

### `project setup` — new `setupGithub` step (github-enabled projects)

- repo settings: **allow auto-merge** + **delete merged branches**
- branch protection on the **default branch** requiring the generated **`catladder ✅`** aggregate check

**Non-destructive by design**: the API's PUT replaces the whole rule, so the step reads existing protection first and carries everything over — enforce-admins, required reviews, restrictions, strictness, *other* required checks — merging the aggregate context in rather than replacing. A rule is only created where none exists. Admins keep the per-PR bypass: a default, not a cage.

### `project doctor` — new merge-gating section

- ❌ auto-merge off → *"the merge-when-pipeline-succeeds button cannot appear"* → heal: `project setup`
- ❌ `catladder ✅` not required → *"PRs can merge while the pipeline is red or still running"* → heal: `project setup`
- ⚠️ additionally required **named** checks → the staleness warning (job names change with every component add/rename)

### Also

- `project setup` on a **github-only** project no longer runs the gitlab provisioning (access token, agent webhooks) against a gitlab that isn't there — and the closing line names the actual backends instead of always claiming "gitlab is ready! 🥂"
- migration skill: the merge-gating bullet shrinks from a hand-rolled `gh api` recipe to "run `project setup` / verify with `doctor`" — skills point at tested commands
- `enforce_admins` and required reviews stay untouched, deliberately: human choices ("Do not allow bypassing" should stay off on generated-CI repos — a generation bug can only be fixed via the bypass)

### Verification

Live-tested against `panter/catladder` itself (already configured by hand): idempotent, `✅ auto-merge already enabled / ✅ 'catladder ✅' already required on main`, zero writes. 270/270 pass, lint clean.