### PR TITLE
feat(catenv): interactive on a terminal, clean failure everywhere else

### DIFF
--- a/.changeset/minor-catenv-interactive.md
+++ b/.changeset/minor-catenv-interactive.md
@@ -1,0 +1,5 @@
+---
+"catladder": minor
+---
+
+catenv is interactive when a human runs it: attached to a terminal it can now run the gitlab token setup and vault unlock prompts, instead of aborting with a `NonInteractiveError` mid-wizard. Under direnv, turbo or CI (stdout not a TTY) it stays non-interactive automatically, and `--non-interactive` forces that on a terminal too. In non-interactive runs a missing gitlab token now fails fast with the remedy ("run `catenv` once in a terminal") rather than starting a prompt it cannot answer, and the bitwarden unlock prompt is suppressed as well.

--- a/apps/cli/src/adapters/terminal.ts
+++ b/apps/cli/src/adapters/terminal.ts
@@ -7,6 +7,7 @@ import type {
   PromptChoice,
 } from "../core/types";
 import { MissingInputError } from "../core/types";
+import type { SecretsMode } from "../vault";
 import { BaseContext } from "./baseContext";
 import { createVaultManagerGetter } from "./vaultManagerAccess";
 
@@ -82,6 +83,13 @@ export interface TerminalOptions {
   interactive?: boolean;
   /** If true, all confirm() calls return true without prompting (--yes flag) */
   yes?: boolean;
+  /**
+   * log to stderr instead of stdout (catenv: stdout may be evaluated
+   * by direnv or piped, so only data belongs there)
+   */
+  logToStderr?: boolean;
+  /** how to interact with the secrets vault (--vault-mode) */
+  vaultMode?: SecretsMode;
 }
 
 class TerminalContext<
@@ -187,9 +195,15 @@ export function createTerminalContext<TInputs extends InputsSchema>(
 export function createTerminalIO(options: TerminalOptions = {}): IO {
   const io: IO = {
     interactive: options.interactive ?? process.stdin.isTTY === true,
-    getVaultManager: createVaultManagerGetter(() => io),
+    getVaultManager: createVaultManagerGetter(() => io, {
+      mode: options.vaultMode,
+    }),
     log(message: string): void {
-      console.log(message);
+      if (options.logToStderr) {
+        console.error(message);
+      } else {
+        console.log(message);
+      }
     },
     async confirm(message: string): Promise<boolean> {
       if (options.yes) return true;

--- a/apps/cli/src/apps/catenv/catenv.ts
+++ b/apps/cli/src/apps/catenv/catenv.ts
@@ -10,11 +10,17 @@ import {
 } from "@catladder/pipeline";
 import type { SecretsMode } from "../../vault";
 import { createNonInteractiveIO } from "../../adapters/nonInteractive";
+import { createTerminalIO } from "../../adapters/terminal";
 
 type Options = {
   verbose?: boolean;
   printVariables?: boolean;
   vaultMode?: SecretsMode;
+  /**
+   * whether prompting is allowed (token setup, vault unlock). Callers
+   * pass the TTY detection result; direnv/turbo/CI runs come out false.
+   */
+  interactive?: boolean;
 };
 export default async (choice?: Choice, options?: Options) => {
   const config = await getProjectConfig();
@@ -22,7 +28,15 @@ export default async (choice?: Choice, options?: Options) => {
     return;
   }
 
-  const io = createNonInteractiveIO({ vaultMode: options?.vaultMode });
+  const io = options?.interactive
+    ? // logs still go to stderr: even on a TTY, stdout is reserved for
+      // data (--print-variables) and may be piped
+      createTerminalIO({
+        interactive: true,
+        logToStderr: true,
+        vaultMode: options?.vaultMode,
+      })
+    : createNonInteractiveIO({ vaultMode: options?.vaultMode });
   const context = { ...createCatenvContext(config), io };
   if (options?.verbose) {
     printVerboseBanner();

--- a/apps/cli/src/catenv.ts
+++ b/apps/cli/src/catenv.ts
@@ -27,6 +27,10 @@ program
       .choices(["auto", "no-prompt", "offline", "refresh"])
       .default("auto"),
   )
+  .option(
+    "--non-interactive",
+    "never prompt (token setup, vault unlock) — assumed automatically when not attached to a terminal (direnv, turbo, CI)",
+  )
   .action(
     (
       envComponent: string | undefined,
@@ -34,12 +38,20 @@ program
         verbose?: boolean;
         printVariables?: boolean;
         vaultMode: SecretsMode;
+        nonInteractive?: boolean;
       },
     ) => {
+      // interactive iff a human is attached: direnv captures stdout,
+      // turbo/CI pipe it — all of those auto-degrade to non-interactive
+      const interactive =
+        !opts.nonInteractive &&
+        process.stdin.isTTY === true &&
+        process.stdout.isTTY === true;
       catenv(envComponent ? parseChoice(envComponent) : null, {
         verbose: opts.verbose ?? false,
         printVariables: opts.printVariables ?? false,
         vaultMode: opts.vaultMode,
+        interactive,
       }).then(() => {
         // we have to exit manually, because we have some file watches
         process.exit();

--- a/apps/cli/src/utils/gitlab.ts
+++ b/apps/cli/src/utils/gitlab.ts
@@ -45,6 +45,13 @@ export const getGitlabToken = async (io: IO | null) => {
       );
       process.exit(1);
     }
+    if (!io.interactive) {
+      // don't start the setup wizard in a context that cannot prompt
+      // (direnv, turbo, CI) — fail with the remedy instead
+      throw new Error(
+        "gitlab token missing — run `catenv` (or any `catladder` command) once in a terminal to set it up",
+      );
+    }
     await setupGitlabToken(io);
   }
   return getPreference(TOKEN_KEY);

--- a/apps/cli/src/vault/VaultManager.ts
+++ b/apps/cli/src/vault/VaultManager.ts
@@ -63,7 +63,10 @@ export class VaultManager {
         return new BitwardenVault(
           this.config,
           vaultConfig,
-          this.mode === "auto" || this.mode === "refresh",
+          // unlock prompts need a mode that allows them AND an IO that
+          // can actually prompt (catenv under direnv/turbo/CI cannot)
+          (this.mode === "auto" || this.mode === "refresh") &&
+            (this.io?.interactive ?? true),
         );
     }
   }


### PR DESCRIPTION
Fixes the trap maw hit: with no gitlab token stored, catenv printed the token-setup banner and then died on the first prompt with a `NonInteractiveError` — regardless of `--vault-mode`. catenv was hard-wired to `createNonInteractiveIO`; the interactivity flag we remembered was `--vault-mode`, whose prompt-allowance only ever reached the **Bitwarden** vault, never the gitlab token path.

## Behaviour now

| context | detection | behaviour |
|---|---|---|
| dev types `catenv` in a terminal | stdin **and** stdout are TTYs | **interactive**: token wizard + vault unlock can prompt |
| direnv | stdout captured → not a TTY | non-interactive |
| turbo dev-stack / CI / pipes | stdout piped | non-interactive |
| `catenv --non-interactive` | explicit | non-interactive, even on a terminal |

catenv is interactive **by default** in the only place a prompt can work — a real terminal — and degrades automatically everywhere else, so direnv/turbo/CI invocations need no flag changes.

## Non-interactive failure is now actionable

- `getGitlabToken` on a non-interactive IO fails immediately with *"gitlab token missing — run `catenv` (or any `catladder` command) once in a terminal to set it up"* — no wizard banner, no `open()`.
- `VaultManager` only allows bitwarden unlock prompts when the mode allows it **and** the IO can actually prompt.

## Notes

- Interactive catenv logs still go to **stderr** (`createTerminalIO({logToStderr})`) — stdout stays reserved for `--print-variables` and direnv evaluation.
- `--vault-mode` is unchanged (default `auto`); it governs vault/cache contact, interactivity governs prompting. `offline` remains the escape hatch for token-less machines.
- 274 tests pass, snapshots untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)