### PR TITLE
feat(audit): audit the whole project, configurable severity level

### DIFF
--- a/.changeset/patch-yarn-audit-workspaces.md
+++ b/.changeset/patch-yarn-audit-workspaces.md
@@ -1,0 +1,5 @@
+---
+"catladder": patch
+---
+
+The generated yarn audit job actually audits the project. `yarn npm audit` checks only the **current** workspace's **direct** dependencies, so in a monorepo it checked the root manifest — which usually has no production dependencies — and the 🛡 audit job passed without looking at a single app. It now runs with `--all --recursive` (every workspace, transitive dependencies), which is what `pnpm audit --prod` and classic `yarn audit` do on their own; classic additionally gets `--groups dependencies` so `--environment production` and its behaviour match. Expect a previously green audit job on a yarn monorepo to start reporting long-standing vulnerabilities — they were always there, nothing was checking.

--- a/.changeset/patch-yarn-audit-workspaces.md
+++ b/.changeset/patch-yarn-audit-workspaces.md
@@ -1,5 +1,7 @@
 ---
-"catladder": patch
+"catladder": minor
 ---
 
 The generated yarn audit job actually audits the project. `yarn npm audit` checks only the **current** workspace's **direct** dependencies, so in a monorepo it checked the root manifest — which usually has no production dependencies — and the 🛡 audit job passed without looking at a single app. It now runs with `--all --recursive` (every workspace, transitive dependencies), which is what `pnpm audit --prod` and classic `yarn audit` do on their own; classic additionally gets `--groups dependencies` so `--environment production` and its behaviour match. Expect a previously green audit job on a yarn monorepo to start reporting long-standing vulnerabilities — they were always there, nothing was checking.
+
+The severity threshold is configurable now: `audit: { level: "high" }` on a build config (`info` | `low` | `moderate` | `high` | `critical`, default `critical`), translated to each package manager's own flag — `pnpm audit --audit-level`, `yarn npm audit --severity`, classic `yarn audit --level`. A custom `audit: { command }` still wins over both.

--- a/.claude/skills/catladder-builds/references/build-types.md
+++ b/.claude/skills/catladder-builds/references/build-types.md
@@ -28,6 +28,16 @@ generated pipeline files.
 `artifactsReports`, `artifacts`, `runnerVariables`, `allowFailure`
 (`allowFailure` defaults to `true` for `audit`).
 
+`audit` additionally takes `level`: `"info" | "low" | "moderate" | "high" |
+"critical"` (default `"critical"`) — the lowest severity that fails the job,
+translated to the package manager's own flag (`pnpm audit --audit-level`,
+`yarn npm audit --severity`, classic `yarn audit --level`). Ignored when
+`command` spells out its own command:
+
+```ts
+audit: { level: "high" },   // fail on high and critical advisories
+```
+
 ## Per-type options & defaults
 
 ### `node`

--- a/.claude/skills/catladder-migrate-package-manager/SKILL.md
+++ b/.claude/skills/catladder-migrate-package-manager/SKILL.md
@@ -46,8 +46,14 @@ change needed:
 | download cache | `.yarn` zip cache | project-local `.pnpm-store`, cache slot scoped by pnpm major |
 | node_modules cache | mutable slot per build dir | **lockfile-keyed** slot (a pnpm install over a foreign tree leaves orphaned `.pnpm` dirs) |
 | docker prod install | `yarn workspaces focus --production` | `pnpm install --prod --frozen-lockfile --filter <pkg>...` |
-| audit job | `yarn npm audit …` | `pnpm audit --prod --audit-level critical` |
+| audit job | `yarn npm audit … --all --recursive` | `pnpm audit --prod --audit-level critical` |
 | build/start defaults | `yarn build` / `yarn start` | `pnpm build` / `pnpm start` |
+
+The audit job is the one place where the two are not equivalent in
+practice: it is easy to have a yarn pipeline whose audit checked nothing
+(before catladder 5 the generated command lacked `--all --recursive`), so
+the pnpm job can turn up long-standing vulnerabilities. Read them as
+pre-existing, not as caused by the migration.
 
 Because the cache keys differ per package manager, the first pnpm
 pipeline runs **cold** (and rebuilds job images). Judge speed on the

--- a/.claude/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
+++ b/.claude/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
@@ -21,7 +21,7 @@ here has bitten a real catladder project during a migration.
 | `yarn run -T x` / `yarn -T x` (berry top-level) | `x` (root `node_modules/.bin` is on the script PATH) |
 | `yarn dlx x` | `pnpm dlx x` |
 | `yarn node x` / `yarn exec x` | `pnpm exec x` |
-| `yarn npm audit --environment production` | `pnpm audit --prod` |
+| `yarn npm audit --environment production --all --recursive` | `pnpm audit --prod` |
 | `yarn bin x` | `pnpm bin x` |
 
 ## Configuration mapping
@@ -93,6 +93,15 @@ politely: it prints a `warn:` line and then crashes on
 `No such built-in module: node:sqlite`. In CI this bites even when the
 job image ships node 22 — the jobs run `nvm install` from `.nvmrc`, so
 an `.nvmrc` of `20` downgrades the image right before the install.
+
+**`pnpm audit` needs no scope flags.** It audits every workspace and the
+whole transitive tree by default, which is what `yarn npm audit` only does
+with `--all --recursive` (without them it checks the current workspace's
+*direct* dependencies — in a monorepo root that is usually nothing at all).
+Expect the pnpm audit job to surface vulnerabilities the yarn one never
+reported. In return `--prod` is stricter than yarn's
+`--environment production`: yarn still reports a devDependency of a
+workspace, pnpm does not.
 
 **`minimumReleaseAge`** defaults to 1440 minutes on pnpm 11: freshly
 published versions are refused. Set it to `0` while migrating (it is a

--- a/apps/docs/docs/3_build.md
+++ b/apps/docs/docs/3_build.md
@@ -33,9 +33,11 @@ It will create a docker-image (if the deployment requires a container) based on 
 
 #### predefined jobs
 
-- lint: will run `yarn lint` in your component
-- audit: will run `yarn audit`
-- test: will run `yarn test`
+- lint: will run `<package manager> lint` in your component
+- audit: audits the production dependencies of every workspace and fails on
+  critical advisories. Lower the threshold with `audit: { level: "high" }`
+  (`info` | `low` | `moderate` | `high` | `critical`)
+- test: will run `<package manager> test`
 
 ### node-static
 
@@ -212,7 +214,9 @@ const config = {
         command: "yarn lint"
       },
       audit: {
-        command: "yarn audit"
+        // the default command audits production dependencies and fails on
+        // critical advisories; `level` moves that threshold
+        level: "critical"
       },
     }
   },

--- a/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
@@ -1987,7 +1987,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2351,7 +2351,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3449,7 +3449,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3846,7 +3846,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/changesets-releases-auto.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/changesets-releases-auto.test.ts.snap
@@ -2021,7 +2021,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2385,7 +2385,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3500,7 +3500,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3897,7 +3897,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/changesets-releases.test.ts.snap
@@ -2042,7 +2042,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2406,7 +2406,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3534,7 +3534,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3931,7 +3931,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
@@ -2016,7 +2016,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2382,7 +2382,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3499,7 +3499,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3900,7 +3900,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
@@ -2325,7 +2325,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="web"
 collapseable_section_end "injectvars"
 cd web
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/web-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2684,7 +2684,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="web"
 collapseable_section_end "injectvars"
 cd web
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/web-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3828,7 +3828,7 @@ create release:
     - export APP_PATH="web"
     - collapseable_section_end "injectvars"
     - cd web
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4219,7 +4219,7 @@ create release:
     - export APP_PATH="web"
     - collapseable_section_end "injectvars"
     - cd web
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
@@ -2032,7 +2032,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2396,7 +2396,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3507,7 +3507,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3908,7 +3908,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
@@ -2016,7 +2016,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2403,7 +2403,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3583,7 +3583,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4007,7 +4007,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
@@ -2011,7 +2011,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2375,7 +2375,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3500,7 +3500,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3897,7 +3897,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
@@ -2016,7 +2016,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2394,7 +2394,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3547,7 +3547,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3961,7 +3961,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
@@ -2016,7 +2016,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2394,7 +2394,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3547,7 +3547,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3961,7 +3961,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
@@ -2016,7 +2016,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2395,7 +2395,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3551,7 +3551,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3966,7 +3966,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
@@ -2970,7 +2970,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="db"
 collapseable_section_end "injectvars"
 cd db
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/db-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3334,7 +3334,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3762,7 +3762,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="db"
 collapseable_section_end "injectvars"
 cd db
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/db-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4129,7 +4129,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -5842,7 +5842,7 @@ create release:
     - export APP_PATH="db"
     - collapseable_section_end "injectvars"
     - cd db
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -6239,7 +6239,7 @@ create release:
     - export APP_PATH="db"
     - collapseable_section_end "injectvars"
     - cd db
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -7216,7 +7216,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -7679,7 +7679,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
@@ -2032,7 +2032,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2396,7 +2396,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3554,7 +3554,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3955,7 +3955,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3483,7 +3483,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3880,7 +3880,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
@@ -2065,7 +2065,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2499,7 +2499,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3820,7 +3820,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4295,7 +4295,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
@@ -3807,7 +3807,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="packages/db1"
 collapseable_section_end "injectvars"
 cd packages/db1
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/db1-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -4219,7 +4219,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="packages/db2"
 collapseable_section_end "injectvars"
 cd packages/db2
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/db2-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -4631,7 +4631,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -5034,7 +5034,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="packages/db1"
 collapseable_section_end "injectvars"
 cd packages/db1
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/db1-lint-review.sh =====
 #!/usr/bin/env bash
@@ -5449,7 +5449,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="packages/db2"
 collapseable_section_end "injectvars"
 cd packages/db2
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/db2-lint-review.sh =====
 #!/usr/bin/env bash
@@ -5864,7 +5864,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -8236,7 +8236,7 @@ create release:
     - export APP_PATH="packages/db1"
     - collapseable_section_end "injectvars"
     - cd packages/db1
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -8683,7 +8683,7 @@ create release:
     - export APP_PATH="packages/db1"
     - collapseable_section_end "injectvars"
     - cd packages/db1
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -9813,7 +9813,7 @@ create release:
     - export APP_PATH="packages/db2"
     - collapseable_section_end "injectvars"
     - cd packages/db2
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -10260,7 +10260,7 @@ create release:
     - export APP_PATH="packages/db2"
     - collapseable_section_end "injectvars"
     - cd packages/db2
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -11390,7 +11390,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -11826,7 +11826,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
@@ -2931,7 +2931,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3329,7 +3329,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/worker-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3727,7 +3727,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4128,7 +4128,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/worker-lint-review.sh =====
 #!/usr/bin/env bash
@@ -5885,7 +5885,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -6316,7 +6316,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -7398,7 +7398,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -7829,7 +7829,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
@@ -2078,7 +2078,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2537,7 +2537,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3916,7 +3916,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4423,7 +4423,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
@@ -2011,7 +2011,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2376,7 +2376,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3489,7 +3489,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3888,7 +3888,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
@@ -2011,7 +2011,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2376,7 +2376,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3489,7 +3489,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3888,7 +3888,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
@@ -1703,7 +1703,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2011,7 +2011,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -2951,7 +2951,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3263,7 +3263,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
@@ -1988,7 +1988,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2360,7 +2360,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3495,7 +3495,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3898,7 +3898,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
@@ -1168,7 +1168,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -1364,7 +1364,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-asdf.sh =====
 #!/usr/bin/env bash
@@ -1560,7 +1560,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-bla.sh =====
 #!/usr/bin/env bash
@@ -1756,7 +1756,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -2353,7 +2353,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -2542,7 +2542,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -2731,7 +2731,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -2920,7 +2920,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
@@ -2125,7 +2125,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2540,7 +2540,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3804,7 +3804,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4256,7 +4256,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2372,7 +2372,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3484,7 +3484,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3881,7 +3881,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
@@ -2923,7 +2923,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3309,7 +3309,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4529,7 +4529,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5025,7 +5025,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
@@ -3019,7 +3019,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3406,7 +3406,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4629,7 +4629,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5130,7 +5130,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
@@ -4163,7 +4163,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -4540,7 +4540,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -4922,7 +4922,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -5295,7 +5295,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -7005,7 +7005,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -7492,7 +7492,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -8729,7 +8729,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -9223,7 +9223,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
@@ -3019,7 +3019,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3437,7 +3437,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4753,7 +4753,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5285,7 +5285,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2356,7 +2356,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3419,7 +3419,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3798,7 +3798,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
@@ -3358,7 +3358,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/web-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3757,7 +3757,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/web-lint-review.sh =====
 #!/usr/bin/env bash
@@ -5083,7 +5083,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5591,7 +5591,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
@@ -898,7 +898,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -1094,7 +1094,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -1659,7 +1659,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -1848,7 +1848,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
@@ -898,7 +898,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -1094,7 +1094,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -1659,7 +1659,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -1848,7 +1848,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
@@ -4867,7 +4867,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app1"
 collapseable_section_end "injectvars"
 cd app1
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app1-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -5268,7 +5268,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app2"
 collapseable_section_end "injectvars"
 cd app2
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app2-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -5684,7 +5684,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="kube"
 collapseable_section_end "injectvars"
 cd kube
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/kube-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -6172,7 +6172,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app1"
 collapseable_section_end "injectvars"
 cd app1
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app1-lint-review.sh =====
 #!/usr/bin/env bash
@@ -6585,7 +6585,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app2"
 collapseable_section_end "injectvars"
 cd app2
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app2-lint-review.sh =====
 #!/usr/bin/env bash
@@ -7018,7 +7018,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="kube"
 collapseable_section_end "injectvars"
 cd kube
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/kube-lint-review.sh =====
 #!/usr/bin/env bash
@@ -9706,7 +9706,7 @@ create release:
     - export APP_PATH="app1"
     - collapseable_section_end "injectvars"
     - cd app1
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -10142,7 +10142,7 @@ create release:
     - export APP_PATH="app1"
     - collapseable_section_end "injectvars"
     - cd app1
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -11245,7 +11245,7 @@ create release:
     - export APP_PATH="app2"
     - collapseable_section_end "injectvars"
     - cd app2
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -11696,7 +11696,7 @@ create release:
     - export APP_PATH="app2"
     - collapseable_section_end "injectvars"
     - cd app2
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -12849,7 +12849,7 @@ create release:
     - export APP_PATH="kube"
     - collapseable_section_end "injectvars"
     - cd kube
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -13525,7 +13525,7 @@ create release:
     - export APP_PATH="kube"
     - collapseable_section_end "injectvars"
     - cd kube
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
@@ -2612,7 +2612,7 @@ export LC_A="L=en_US.UTF-8"
 export LANG="en_US.UTF-8"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2881,7 +2881,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3247,7 +3247,7 @@ export LC_A="L=en_US.UTF-8"
 export LANG="en_US.UTF-8"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3516,7 +3516,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4907,7 +4907,7 @@ create release:
     - export LANG="en_US.UTF-8"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5192,7 +5192,7 @@ create release:
     - export LANG="en_US.UTF-8"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5813,7 +5813,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -6210,7 +6210,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
@@ -1988,7 +1988,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2352,7 +2352,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3463,7 +3463,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3857,7 +3857,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
@@ -2008,7 +2008,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2374,7 +2374,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3491,7 +3491,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3890,7 +3890,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
@@ -1112,7 +1112,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="lib"
 collapseable_section_end "injectvars"
 cd lib
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/lib-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -1356,7 +1356,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="lib"
 collapseable_section_end "injectvars"
 cd lib
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/lib-lint-review.sh =====
 #!/usr/bin/env bash
@@ -1966,7 +1966,7 @@ create release:
     - export APP_PATH="lib"
     - collapseable_section_end "injectvars"
     - cd lib
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -2207,7 +2207,7 @@ create release:
     - export APP_PATH="lib"
     - collapseable_section_end "injectvars"
     - cd lib
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
@@ -2037,7 +2037,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/my-app-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2406,7 +2406,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app"
 collapseable_section_end "injectvars"
 cd app
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/my-app-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3537,7 +3537,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3939,7 +3939,7 @@ create release:
     - export APP_PATH="app"
     - collapseable_section_end "injectvars"
     - cd app
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
@@ -2010,7 +2010,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2374,7 +2374,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3485,7 +3485,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3882,7 +3882,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
@@ -4727,7 +4727,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app1"
 collapseable_section_end "injectvars"
 cd app1
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app1-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -5116,7 +5116,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app2"
 collapseable_section_end "injectvars"
 cd app2
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app2-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -5515,7 +5515,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="kube"
 collapseable_section_end "injectvars"
 cd kube
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app3-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -5922,7 +5922,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app1"
 collapseable_section_end "injectvars"
 cd app1
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app1-lint-review.sh =====
 #!/usr/bin/env bash
@@ -6314,7 +6314,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="app2"
 collapseable_section_end "injectvars"
 cd app2
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app2-lint-review.sh =====
 #!/usr/bin/env bash
@@ -6716,7 +6716,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="kube"
 collapseable_section_end "injectvars"
 cd kube
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/app3-lint-review.sh =====
 #!/usr/bin/env bash
@@ -9071,7 +9071,7 @@ create release:
     - export APP_PATH="app1"
     - collapseable_section_end "injectvars"
     - cd app1
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -9493,7 +9493,7 @@ create release:
     - export APP_PATH="app1"
     - collapseable_section_end "injectvars"
     - cd app1
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -10545,7 +10545,7 @@ create release:
     - export APP_PATH="app2"
     - collapseable_section_end "injectvars"
     - cd app2
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -10977,7 +10977,7 @@ create release:
     - export APP_PATH="app2"
     - collapseable_section_end "injectvars"
     - cd app2
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -12059,7 +12059,7 @@ create release:
     - export APP_PATH="kube"
     - collapseable_section_end "injectvars"
     - cd kube
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -12588,7 +12588,7 @@ create release:
     - export APP_PATH="kube"
     - collapseable_section_end "injectvars"
     - cd kube
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
@@ -1617,7 +1617,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -1859,7 +1859,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2101,7 +2101,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="api"
 collapseable_section_end "injectvars"
 cd api
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/api-lint-review.sh =====
 #!/usr/bin/env bash
@@ -2343,7 +2343,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="www"
 collapseable_section_end "injectvars"
 cd www
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/www-lint-review.sh =====
 #!/usr/bin/env bash
@@ -3270,7 +3270,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3509,7 +3509,7 @@ create release:
     - export APP_PATH="api"
     - collapseable_section_end "injectvars"
     - cd api
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4006,7 +4006,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4247,7 +4247,7 @@ create release:
     - export APP_PATH="www"
     - collapseable_section_end "injectvars"
     - cd www
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
@@ -2472,7 +2472,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="."
 collapseable_section_end "injectvars"
 cd .
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/ws-myworkspace-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3000,7 +3000,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="."
 collapseable_section_end "injectvars"
 cd .
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/ws-myworkspace-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4608,7 +4608,7 @@ create release:
     - export APP_PATH="."
     - collapseable_section_end "injectvars"
     - cd .
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4816,7 +4816,7 @@ create release:
     - export APP_PATH="."
     - collapseable_section_end "injectvars"
     - cd .
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
@@ -2460,7 +2460,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="."
 collapseable_section_end "injectvars"
 cd .
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/ws-myworkspace-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -2986,7 +2986,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="."
 collapseable_section_end "injectvars"
 cd .
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/ws-myworkspace-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4588,7 +4588,7 @@ create release:
     - export APP_PATH="."
     - collapseable_section_end "injectvars"
     - cd .
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4794,7 +4794,7 @@ create release:
     - export APP_PATH="."
     - collapseable_section_end "injectvars"
     - cd .
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
@@ -2594,7 +2594,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="."
 collapseable_section_end "injectvars"
 cd .
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/ws-myworkspace-lint-dev.sh =====
 #!/usr/bin/env bash
@@ -3180,7 +3180,7 @@ collapseable_section_start "injectvars" "Injecting variables"
 export APP_PATH="."
 collapseable_section_end "injectvars"
 cd .
-yarn npm audit --environment production --severity critical
+yarn npm audit --environment production --severity critical --all --recursive
 
 # ===== .catladder-generated/github/scripts/ws-myworkspace-lint-review.sh =====
 #!/usr/bin/env bash
@@ -4962,7 +4962,7 @@ create release:
     - export APP_PATH="."
     - collapseable_section_end "injectvars"
     - cd .
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5163,7 +5163,7 @@ create release:
     - export APP_PATH="."
     - collapseable_section_end "injectvars"
     - cd .
-    - yarn npm audit --environment production --severity critical
+    - yarn npm audit --environment production --severity critical --all --recursive
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/src/build/node/__tests__/auditCommand.test.ts
+++ b/packages/pipeline/src/build/node/__tests__/auditCommand.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultAuditCommand } from "../packageManagerInstall";
+
+const pnpm = { type: "pnpm", version: "11.20.0", workspaces: [] } as any;
+const yarnBerry = {
+  type: "yarn",
+  version: "4.0.0",
+  isClassic: false,
+  workspaces: [],
+} as any;
+const yarnClassic = { ...yarnBerry, version: "1.22.22", isClassic: true };
+
+describe("default audit command", () => {
+  it("fails on critical advisories by default", () => {
+    expect(getDefaultAuditCommand(pnpm)).toBe(
+      "pnpm audit --prod --audit-level critical",
+    );
+    expect(getDefaultAuditCommand(yarnBerry)).toBe(
+      "yarn npm audit --environment production --severity critical --all --recursive",
+    );
+    expect(getDefaultAuditCommand(yarnClassic)).toBe(
+      "yarn audit --level critical --groups dependencies",
+    );
+  });
+
+  it("takes the configured level, in each package manager's own flag", () => {
+    expect(getDefaultAuditCommand(pnpm, "high")).toContain(
+      "--audit-level high",
+    );
+    expect(getDefaultAuditCommand(yarnBerry, "high")).toContain(
+      "--severity high",
+    );
+    expect(getDefaultAuditCommand(yarnClassic, "high")).toContain(
+      "--level high",
+    );
+  });
+
+  it("audits every workspace and the transitive tree on yarn berry", () => {
+    // without these, `yarn npm audit` only checks the current workspace's
+    // direct dependencies — in a monorepo root, usually nothing at all
+    const command = getDefaultAuditCommand(yarnBerry);
+    expect(command).toContain("--all");
+    expect(command).toContain("--recursive");
+  });
+
+  it("throws for a package manager without an audit command", () => {
+    expect(() => getDefaultAuditCommand({ type: "npm" } as any)).toThrow(
+      /no audit command implemented/,
+    );
+  });
+});

--- a/packages/pipeline/src/build/node/packageManagerInstall.ts
+++ b/packages/pipeline/src/build/node/packageManagerInstall.ts
@@ -4,6 +4,7 @@ import type {
   PackageManagerInfoBase,
   PackageManagerInfoComponent,
 } from "../../types";
+import type { AuditLevel } from "../types";
 import { type Context } from "../../types";
 import { ensureArray } from "../../utils";
 import { collapseableSection } from "../../utils/gitlab";
@@ -60,28 +61,32 @@ const getPnpmInstallCommands = (
   `pnpm install --frozen-lockfile --store-dir ${getPnpmStoreDirExpression(isInWorkspace(context, packageManagerInfo))}`,
 ];
 
+export const DEFAULT_AUDIT_LEVEL: AuditLevel = "critical";
+
 /**
- * default `audit` job command per package manager. Exhaustive on the
- * package-manager type and throws for anything unsupported, so adding a
- * new package manager surfaces every place that needs a command here.
+ * default `audit` job command per package manager, failing on advisories
+ * of `level` and above. Exhaustive on the package-manager type and throws
+ * for anything unsupported, so adding a new package manager surfaces every
+ * place that needs a command here.
  */
 export const getDefaultAuditCommand = (
   packageManagerInfo: PackageManagerInfoBase,
+  level: AuditLevel = DEFAULT_AUDIT_LEVEL,
 ): string => {
   switch (packageManagerInfo.type) {
     case "pnpm":
-      return "pnpm audit --prod --audit-level critical";
+      return `pnpm audit --prod --audit-level ${level}`;
     case "yarn":
       return packageManagerInfo.isClassic
         ? // classic walks the whole tree; --groups limits it to production
-          "yarn audit --level critical --groups dependencies"
+          `yarn audit --level ${level} --groups dependencies`
         : // yarn 2+ audits only the CURRENT workspace's DIRECT dependencies
           // by default — in a monorepo that is the root manifest, which
           // usually has no production dependencies at all, so the job passed
           // without checking anything. --all covers every workspace,
           // --recursive the transitive dependencies (what `pnpm audit` and
           // `yarn audit` classic do on their own).
-          "yarn npm audit --environment production --severity critical --all --recursive";
+          `yarn npm audit --environment production --severity ${level} --all --recursive`;
     default:
       throw new Error(
         `no audit command implemented for package manager "${(packageManagerInfo as { type: string }).type}"`,

--- a/packages/pipeline/src/build/node/packageManagerInstall.ts
+++ b/packages/pipeline/src/build/node/packageManagerInstall.ts
@@ -73,8 +73,15 @@ export const getDefaultAuditCommand = (
       return "pnpm audit --prod --audit-level critical";
     case "yarn":
       return packageManagerInfo.isClassic
-        ? "yarn audit --level critical"
-        : "yarn npm audit --environment production --severity critical"; // yarn 2+
+        ? // classic walks the whole tree; --groups limits it to production
+          "yarn audit --level critical --groups dependencies"
+        : // yarn 2+ audits only the CURRENT workspace's DIRECT dependencies
+          // by default — in a monorepo that is the root manifest, which
+          // usually has no production dependencies at all, so the job passed
+          // without checking anything. --all covers every workspace,
+          // --recursive the transitive dependencies (what `pnpm audit` and
+          // `yarn audit` classic do on their own).
+          "yarn npm audit --environment production --severity critical --all --recursive";
     default:
       throw new Error(
         `no audit command implemented for package manager "${(packageManagerInfo as { type: string }).type}"`,

--- a/packages/pipeline/src/build/node/testJob.ts
+++ b/packages/pipeline/src/build/node/testJob.ts
@@ -71,7 +71,10 @@ export const createNodeTestJobs = async (
           script: [
             `cd ${context.build.dir}`,
             ...(ensureArrayOrNull(buildConfig.audit?.command) ?? [
-              getDefaultAuditCommand(packageManagerInfo),
+              getDefaultAuditCommand(
+                packageManagerInfo,
+                buildConfig.audit?.level,
+              ),
             ]),
           ],
           allow_failure: buildConfig.audit?.allowFailure ?? true,

--- a/packages/pipeline/src/build/types.ts
+++ b/packages/pipeline/src/build/types.ts
@@ -123,6 +123,22 @@ export type TestJobCustom = {
   allowFailure?: boolean;
 };
 
+/**
+ * severity threshold of the 🛡 audit job: an advisory at this level or
+ * above fails the job. Maps to the package manager's own flag
+ * (`pnpm audit --audit-level`, `yarn npm audit --severity`,
+ * classic `yarn audit --level`).
+ */
+export type AuditLevel = "info" | "low" | "moderate" | "high" | "critical";
+
+export type AuditJobCustom = TestJobCustom & {
+  /**
+   * lowest severity that fails the job, defaults to `"critical"`.
+   * Ignored when {@link TestJobCustom.command} spells out its own command.
+   */
+  level?: AuditLevel;
+};
+
 export type BuildConfigBase = {
   /**
    * command to run on the image to start the app (e.g. yarn start)
@@ -159,7 +175,7 @@ export type BuildConfigBase = {
   /**
    * customize audit, set false to disable
    */
-  audit?: false | TestJobCustom;
+  audit?: false | AuditJobCustom;
 
   /**
    * additional paths for artifacts,
@@ -326,7 +342,7 @@ export type BuildConfigCustom = Omit<
   /**
    * custom audit, disabled when not set
    */
-  audit?: TestJobCustom;
+  audit?: AuditJobCustom;
 };
 
 export type BuildConfigRails = BuildConfigBase & {
@@ -443,7 +459,7 @@ export type WorkspaceBuildConfigBase = {
   /**
    * customize audit, set false to disable
    */
-  audit?: false | TestJobCustom;
+  audit?: false | AuditJobCustom;
   /**
    * additional vars only for the build job.
    * Also if you use services: that require env vars, you need to set them here.

--- a/skills/catladder-builds/references/build-types.md
+++ b/skills/catladder-builds/references/build-types.md
@@ -26,6 +26,16 @@ generated pipeline files.
 `artifactsReports`, `artifacts`, `runnerVariables`, `allowFailure`
 (`allowFailure` defaults to `true` for `audit`).
 
+`audit` additionally takes `level`: `"info" | "low" | "moderate" | "high" |
+"critical"` (default `"critical"`) — the lowest severity that fails the job,
+translated to the package manager's own flag (`pnpm audit --audit-level`,
+`yarn npm audit --severity`, classic `yarn audit --level`). Ignored when
+`command` spells out its own command:
+
+```ts
+audit: { level: "high" },   // fail on high and critical advisories
+```
+
 ## Per-type options & defaults
 
 ### `node`

--- a/skills/catladder-migrate-package-manager/SKILL.md
+++ b/skills/catladder-migrate-package-manager/SKILL.md
@@ -44,8 +44,14 @@ change needed:
 | download cache | `.yarn` zip cache | project-local `.pnpm-store`, cache slot scoped by pnpm major |
 | node_modules cache | mutable slot per build dir | **lockfile-keyed** slot (a pnpm install over a foreign tree leaves orphaned `.pnpm` dirs) |
 | docker prod install | `yarn workspaces focus --production` | `pnpm install --prod --frozen-lockfile --filter <pkg>...` |
-| audit job | `yarn npm audit …` | `pnpm audit --prod --audit-level critical` |
+| audit job | `yarn npm audit … --all --recursive` | `pnpm audit --prod --audit-level critical` |
 | build/start defaults | `yarn build` / `yarn start` | `pnpm build` / `pnpm start` |
+
+The audit job is the one place where the two are not equivalent in
+practice: it is easy to have a yarn pipeline whose audit checked nothing
+(before catladder 5 the generated command lacked `--all --recursive`), so
+the pnpm job can turn up long-standing vulnerabilities. Read them as
+pre-existing, not as caused by the migration.
 
 Because the cache keys differ per package manager, the first pnpm
 pipeline runs **cold** (and rebuilds job images). Judge speed on the

--- a/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
+++ b/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
@@ -19,7 +19,7 @@ here has bitten a real catladder project during a migration.
 | `yarn run -T x` / `yarn -T x` (berry top-level) | `x` (root `node_modules/.bin` is on the script PATH) |
 | `yarn dlx x` | `pnpm dlx x` |
 | `yarn node x` / `yarn exec x` | `pnpm exec x` |
-| `yarn npm audit --environment production` | `pnpm audit --prod` |
+| `yarn npm audit --environment production --all --recursive` | `pnpm audit --prod` |
 | `yarn bin x` | `pnpm bin x` |
 
 ## Configuration mapping
@@ -91,6 +91,15 @@ politely: it prints a `warn:` line and then crashes on
 `No such built-in module: node:sqlite`. In CI this bites even when the
 job image ships node 22 — the jobs run `nvm install` from `.nvmrc`, so
 an `.nvmrc` of `20` downgrades the image right before the install.
+
+**`pnpm audit` needs no scope flags.** It audits every workspace and the
+whole transitive tree by default, which is what `yarn npm audit` only does
+with `--all --recursive` (without them it checks the current workspace's
+*direct* dependencies — in a monorepo root that is usually nothing at all).
+Expect the pnpm audit job to surface vulnerabilities the yarn one never
+reported. In return `--prod` is stricter than yarn's
+`--environment production`: yarn still reports a devDependency of a
+workspace, pnpm does not.
 
 **`minimumReleaseAge`** defaults to 1440 minutes on pnpm 11: freshly
 published versions are refused. Set it to `0` while migrating (it is a


### PR DESCRIPTION
maw asked whether our audit commands are wrong. One of them was — and the severity threshold is configurable now.

## The yarn command audited nothing

`yarn npm audit` checks only the **current** workspace's **direct** dependencies. In a monorepo that is the root manifest, which usually has no production dependencies — so the generated `🛡 audit` job has been passing without looking at a single app.

Measured on food-2050 (78 workspaces), same lockfile, same day:

| command | criticals |
|---|---|
| `yarn npm audit --environment production --severity critical` (what we generated) | **0** — "No audit suggestions" |
| … `--all` | 2 (direct dependencies only) |
| … `--all --recursive` | **12** |
| `pnpm audit --prod --audit-level critical` (what we generate for pnpm) | **11** |

`--all` covers every workspace, `--recursive` the transitive tree — which `pnpm audit` and classic `yarn audit` already do on their own. Classic additionally gets `--groups dependencies`: it walks the whole tree anyway, but without that flag it also audited devDependencies, so it did not honour the production-only intent either (that change makes classic audits *narrower*).

## Configurable level

```ts
audit: { level: "high" },   // fail on high and critical advisories
```

`info` | `low` | `moderate` | `high` | `critical`, default `critical`, translated per package manager (`--audit-level` / `--severity` / `--level`). A custom `audit: { command }` still wins over both, and `audit: false` still disables the job.

## Not identical afterwards

yarn still reports a devDependency of a workspace (`vitest` via `@repo/date-utils`) despite `--environment production`; pnpm's `--prod` skips it. So a yarn project may see a hit a pnpm project does not — worth knowing before treating the two as interchangeable.

## Impact on consumers

A yarn monorepo whose audit job is green today will likely start reporting. Those vulnerabilities are not new — nothing was checking them. The job keeps `allow_failure: true` by default, so it reports rather than blocks; `audit: { allowFailure: false }` if you want it to block, `audit: { level: … }` to tune the threshold.

Snapshots change for every yarn example (the command line is the only diff), plus unit tests for the command builder and docs in the builds skill and the build page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)