### PR TITLE
feat(cache)!: pnpm builds run uncached, and the store stays out of docker images

### DIFF
--- a/.changeset/pnpm-store-only-cache.md
+++ b/.changeset/pnpm-store-only-cache.md
@@ -1,0 +1,31 @@
+---
+"catladder": minor
+---
+
+pnpm projects now run CI without any dependency cache, and the pnpm
+store no longer travels into docker images.
+
+Measured on a 3800-package monorepo, with every configuration run as
+jobs in the same pipeline so they shared fleet conditions:
+
+- **node_modules cache**: restoring it (1.29 GB, 348k files) cost ~125s
+  to save 6s of install; writing it cost ~190s more.
+- **store cache**: on gitlab a job with the store took 74s against 35s
+  with no cache at all — the restore alone (53s) exceeded a full
+  from-registry install (30-42s), because the runner zips the store file
+  by file. On github (single zstd stream) it was a wash: ~60s vs ~64s.
+- **store in the docker image**: the worst of the three. The store is
+  copied into a layer *below* node_modules, so pnpm cannot hardlink
+  across the overlay boundary and copies every package instead. The
+  in-image install was *slower* that way (28.4s vs 9.6s from the
+  registry), while adding 3 GB to the build context and to the shipped
+  image: build 339s → 27s, image 3.35 GB → 0.73 GB.
+
+So pnpm builds now: install with no cache, use pnpm's own store location
+instead of a project-local `.pnpm-store` (nothing to cache, nothing to
+leak into a build context), and let the docker `--prod` install download
+from the registry — into scratch space that is dropped in the same layer,
+so packages ship once.
+
+Generated pipelines lose all pnpm `cache:` blocks and the
+`COPY .pnpm-store` line. Yarn caching is unchanged.

--- a/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
@@ -347,20 +347,6 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 👮 lint
           id: main
           run: bash .catladder-generated/github/scripts/www-lint-dev.sh
@@ -383,20 +369,6 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 🧪 test
           id: main
           run: bash .catladder-generated/github/scripts/www-test-dev.sh
@@ -419,26 +391,12 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
         - name: Cache www-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: www-default-\${{ github.run_id }}
             restore-keys: www-default-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/www-app-dev.sh
@@ -473,12 +431,6 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from www-app-dev
           uses: actions/download-artifact@v4
           with:
@@ -718,20 +670,6 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 👮 lint
           id: main
           run: bash .catladder-generated/github/scripts/www-lint-review.sh
@@ -754,20 +692,6 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 🧪 test
           id: main
           run: bash .catladder-generated/github/scripts/www-test-review.sh
@@ -790,26 +714,12 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
         - name: Cache www-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: www-default-\${{ github.run_id }}
             restore-keys: www-default-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/www-app-review.sh
@@ -844,12 +754,6 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from www-app-review
           uses: actions/download-artifact@v4
           with:
@@ -1085,26 +989,12 @@ catladder-release.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
         - name: Cache www-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: www-default-\${{ github.run_id }}
             restore-keys: www-default-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/www-app-stage.sh
@@ -1139,12 +1029,6 @@ catladder-release.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from www-app-stage
           uses: actions/download-artifact@v4
           with:
@@ -1575,26 +1459,12 @@ catladder-deploy.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-www-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: www/node_modules
-            key: pnpm-www-node-modules-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: pnpm-www-node-modules-
         - name: Cache www-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: www-default-\${{ github.run_id }}
             restore-keys: www-default-
-        - name: Cache www-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/www-app-prod.sh
@@ -1629,12 +1499,6 @@ catladder-deploy.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from www-app-prod
           uses: actions/download-artifact@v4
           with:
@@ -2061,7 +1925,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm lint
 
@@ -2108,7 +1972,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm test
 
@@ -2186,7 +2050,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -2228,7 +2092,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -2426,7 +2290,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm lint
 
@@ -2473,7 +2337,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm test
 
@@ -2551,7 +2415,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -2593,7 +2457,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -2790,7 +2654,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -2832,7 +2696,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -3026,7 +2890,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -3068,7 +2932,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -3525,21 +3389,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm lint
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
-    - key: &a8
-        prefix: pnpm-www-node-modules
-        files:
-          - www/pnpm-lock.yaml
-      policy: pull
-      paths: &a9
-        - www/node_modules
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3572,17 +3424,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm test
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
-    - key: *a8
-      policy: pull
-      paths: *a9
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3647,21 +3491,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: www-pnpm-v10
-      policy: pull-push
-      paths:
-        - www/.pnpm-store
-    - key:
-        prefix: pnpm-www-node-modules
-        files:
-          - www/pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - www/node_modules
     - key: www-default
       policy: pull-push
       paths:
@@ -3714,7 +3547,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -3734,11 +3567,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3931,23 +3759,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm lint
-  cache:
-    - key: www-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull
-      paths:
-        - www/.pnpm-store
-      fallback_keys:
-        - www-pnpm-v10
-    - key: &a10
-        prefix: pnpm-www-node-modules
-        files:
-          - www/pnpm-lock.yaml
-      policy: pull
-      paths: &a11
-        - www/node_modules
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -3980,19 +3794,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm test
-  cache:
-    - key: www-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull
-      paths:
-        - www/.pnpm-store
-      fallback_keys:
-        - www-pnpm-v10
-    - key: *a10
-      policy: pull
-      paths: *a11
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4057,23 +3861,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: www-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull-push
-      paths:
-        - www/.pnpm-store
-      fallback_keys:
-        - www-pnpm-v10
-    - key:
-        prefix: pnpm-www-node-modules
-        files:
-          - www/pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - www/node_modules
     - key: www-default-mr$CI_MERGE_REQUEST_IID
       policy: pull-push
       paths:
@@ -4128,7 +3919,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -4148,13 +3939,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull
-      paths:
-        - www/.pnpm-store
-      fallback_keys:
-        - www-pnpm-v10
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4361,21 +4145,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: www-pnpm-v10
-      policy: pull-push
-      paths:
-        - www/.pnpm-store
-    - key:
-        prefix: pnpm-www-node-modules
-        files:
-          - www/pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - www/node_modules
     - key: www-default
       policy: pull-push
       paths:
@@ -4428,7 +4201,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -4448,11 +4221,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4646,21 +4414,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$PWD/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: www-pnpm-v10
-      policy: pull-push
-      paths:
-        - www/.pnpm-store
-    - key:
-        prefix: pnpm-www-node-modules
-        files:
-          - www/pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - www/node_modules
     - key: www-default
       policy: pull-push
       paths:
@@ -4713,7 +4470,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -4733,11 +4490,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
@@ -341,20 +341,6 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 👮 lint
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-lint-dev.sh
@@ -374,20 +360,6 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 🧪 test
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-test-dev.sh
@@ -411,26 +383,12 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
         - name: Cache myWorkspace-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: myWorkspace-default-\${{ github.run_id }}
             restore-keys: myWorkspace-default-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-app-dev.sh
@@ -466,12 +424,6 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache api-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: api/.pnpm-store
-            key: api-pnpm-v10-\${{ hashFiles('api/pnpm-lock.yaml') }}
-            restore-keys: api-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-dev
           uses: actions/download-artifact@v4
           with:
@@ -523,12 +475,6 @@ catladder-main.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-dev
           uses: actions/download-artifact@v4
           with:
@@ -761,20 +707,6 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 👮 lint
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-lint-review.sh
@@ -794,20 +726,6 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache/restore@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache/restore@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 🧪 test
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-test-review.sh
@@ -831,26 +749,12 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
         - name: Cache myWorkspace-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: myWorkspace-default-\${{ github.run_id }}
             restore-keys: myWorkspace-default-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-app-review.sh
@@ -886,12 +790,6 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache api-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: api/.pnpm-store
-            key: api-pnpm-v10-\${{ hashFiles('api/pnpm-lock.yaml') }}
-            restore-keys: api-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-review
           uses: actions/download-artifact@v4
           with:
@@ -943,12 +841,6 @@ catladder-review.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-review
           uses: actions/download-artifact@v4
           with:
@@ -1186,26 +1078,12 @@ catladder-release.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
         - name: Cache myWorkspace-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: myWorkspace-default-\${{ github.run_id }}
             restore-keys: myWorkspace-default-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-app-stage.sh
@@ -1241,12 +1119,6 @@ catladder-release.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache api-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: api/.pnpm-store
-            key: api-pnpm-v10-\${{ hashFiles('api/pnpm-lock.yaml') }}
-            restore-keys: api-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-stage
           uses: actions/download-artifact@v4
           with:
@@ -1295,12 +1167,6 @@ catladder-release.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-stage
           uses: actions/download-artifact@v4
           with:
@@ -1791,26 +1657,12 @@ catladder-deploy.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache pnpm-.-node-modules
-          id: cache-node-modules
-          uses: actions/cache@v4
-          with:
-            path: node_modules
-            key: pnpm-.-node-modules-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: pnpm-.-node-modules-
         - name: Cache myWorkspace-default
           uses: actions/cache@v4
           with:
             path: www/.next/cache
             key: myWorkspace-default-\${{ github.run_id }}
             restore-keys: myWorkspace-default-
-        - name: Cache .-pnpm-v10
-          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-          uses: actions/cache@v4
-          with:
-            path: .pnpm-store
-            key: .-pnpm-v10-\${{ hashFiles('pnpm-lock.yaml') }}
-            restore-keys: .-pnpm-v10-
         - name: 🔨 app
           id: main
           run: bash .catladder-generated/github/scripts/ws-myworkspace-app-prod.sh
@@ -1847,12 +1699,6 @@ catladder-deploy.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache api-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: api/.pnpm-store
-            key: api-pnpm-v10-\${{ hashFiles('api/pnpm-lock.yaml') }}
-            restore-keys: api-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-prod
           uses: actions/download-artifact@v4
           with:
@@ -1903,12 +1749,6 @@ catladder-deploy.yml:
       steps:
         - name: Checkout
           uses: actions/checkout@v4
-        - name: Cache www-pnpm-v10
-          uses: actions/cache/restore@v4
-          with:
-            path: www/.pnpm-store
-            key: www-pnpm-v10-\${{ hashFiles('www/pnpm-lock.yaml') }}
-            restore-keys: www-pnpm-v10-
         - name: Download artifacts from ws-myworkspace-app-prod
           uses: actions/download-artifact@v4
           with:
@@ -2489,7 +2329,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm lint
 
@@ -2536,7 +2376,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm test
 
@@ -2615,7 +2455,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -2657,7 +2497,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -2815,7 +2655,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -3016,7 +2856,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm lint
 
@@ -3063,7 +2903,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm test
 
@@ -3142,7 +2982,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -3184,7 +3024,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -3345,7 +3185,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -3546,7 +3386,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -3625,7 +3465,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build
 
@@ -3667,7 +3507,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -3825,7 +3665,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -3983,7 +3823,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -4144,7 +3984,7 @@ export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladd
 export DOCKER_IMAGE_TAG="$GITHUB_SHA"
 export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
 export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
 RUN chown -R node:node /app || true"
 export DOCKER_SETUP_PACKAGE_MANAGER="RUN npm install -g pnpm@10.14.0"
@@ -4606,21 +4446,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm lint
-  cache:
-    - key: .-pnpm-v10
-      policy: pull
-      paths:
-        - .pnpm-store
-    - key: &a8
-        prefix: pnpm-.-node-modules
-        files:
-          - pnpm-lock.yaml
-      policy: pull
-      paths: &a9
-        - node_modules
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4653,17 +4481,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm test
-  cache:
-    - key: .-pnpm-v10
-      policy: pull
-      paths:
-        - .pnpm-store
-    - key: *a8
-      policy: pull
-      paths: *a9
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4730,21 +4550,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: .-pnpm-v10
-      policy: pull-push
-      paths:
-        - .pnpm-store
-    - key:
-        prefix: pnpm-.-node-modules
-        files:
-          - pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - node_modules
     - key: myWorkspace-default
       policy: pull-push
       paths:
@@ -4819,23 +4628,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm lint
-  cache:
-    - key: .-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull
-      paths:
-        - .pnpm-store
-      fallback_keys:
-        - .-pnpm-v10
-    - key: &a10
-        prefix: pnpm-.-node-modules
-        files:
-          - pnpm-lock.yaml
-      policy: pull
-      paths: &a11
-        - node_modules
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4868,19 +4663,9 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm test
-  cache:
-    - key: .-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull
-      paths:
-        - .pnpm-store
-      fallback_keys:
-        - .-pnpm-v10
-    - key: *a10
-      policy: pull
-      paths: *a11
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -4947,23 +4732,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: .-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull-push
-      paths:
-        - .pnpm-store
-      fallback_keys:
-        - .-pnpm-v10
-    - key:
-        prefix: pnpm-.-node-modules
-        files:
-          - pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - node_modules
     - key: myWorkspace-default-mr$CI_MERGE_REQUEST_IID
       policy: pull-push
       paths:
@@ -5050,21 +4822,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: .-pnpm-v10
-      policy: pull-push
-      paths:
-        - .pnpm-store
-    - key:
-        prefix: pnpm-.-node-modules
-        files:
-          - pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - node_modules
     - key: myWorkspace-default
       policy: pull-push
       paths:
@@ -5149,21 +4910,10 @@ create release:
     - collapseable_section_end "nodeinstall"
     - collapseable_section_start "pnpminstall" "pnpm install"
     - if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@10.14.0; fi
-    - pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+    - pnpm install --frozen-lockfile
     - collapseable_section_end "pnpminstall"
     - pnpm build
   cache:
-    - key: .-pnpm-v10
-      policy: pull-push
-      paths:
-        - .pnpm-store
-    - key:
-        prefix: pnpm-.-node-modules
-        files:
-          - pnpm-lock.yaml
-      policy: pull-push
-      paths:
-        - node_modules
     - key: myWorkspace-default
       policy: pull-push
       paths:
@@ -5219,7 +4969,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -5239,11 +4989,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: api-pnpm-v10
-      policy: pull
-      paths:
-        - api/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5416,7 +5161,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -5436,13 +5181,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: api-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull
-      paths:
-        - api/.pnpm-store
-      fallback_keys:
-        - api-pnpm-v10
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5621,7 +5359,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -5641,11 +5379,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: api-pnpm-v10
-      policy: pull
-      paths:
-        - api/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -5811,7 +5544,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -5831,11 +5564,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: api-pnpm-v10
-      policy: pull
-      paths:
-        - api/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -6001,7 +5729,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -6021,11 +5749,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -6201,7 +5924,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -6221,13 +5944,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10-mr$CI_MERGE_REQUEST_IID
-      policy: pull
-      paths:
-        - www/.pnpm-store
-      fallback_keys:
-        - www-pnpm-v10
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -6409,7 +6125,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -6429,11 +6145,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"
@@ -6602,7 +6313,7 @@ create release:
     - |-
       export DOCKER_COPY_AND_INSTALL_APP="COPY --chown=node:node $APP_DIR .
       RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@10.14.0
-      RUN pnpm install --prod --frozen-lockfile --store-dir /app/$APP_DIR/.pnpm-store"
+      RUN pnpm install --prod --frozen-lockfile --store-dir /tmp/pnpm-store && rm -rf /tmp/pnpm-store"
     - |-
       export DOCKER_COPY_WORKSPACE_FILES="ADD .catladder-workspace-files.tar /app/
       RUN chown -R node:node /app || true"
@@ -6622,11 +6333,6 @@ create release:
     - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
     - docker push $DOCKER_CACHE_IMAGE
     - collapseable_section_end "docker-push"
-  cache:
-    - key: www-pnpm-v10
-      policy: pull
-      paths:
-        - www/.pnpm-store
   rules:
     - when: never
       if: $CI_PIPELINE_SOURCE  == "trigger"

--- a/packages/pipeline/src/build/node/buildJob.ts
+++ b/packages/pipeline/src/build/node/buildJob.ts
@@ -73,12 +73,14 @@ export const createNodeDockerJobDefinition = async (
       context.packageManagerInfo,
     ]);
 
-  // the pnpm store (pulled via the cache above) is copied into the
-  // image so the prod install works offline — like the yarn zip cache,
-  // which travels inside the copied `.yarn` config folder
-  const copyPnpmStore =
-    packageManagerInfo.type === "pnpm" &&
-    packageManagerInfo.componentIsInWorkspace;
+  // The pnpm store is deliberately NOT copied into the image. It used
+  // to be, so the prod install could link instead of hitting the
+  // registry — but the store lands in an earlier layer than
+  // node_modules, so pnpm cannot hardlink across the overlay boundary
+  // and copies every package instead. Measured on one component: the
+  // in-image install was *slower* that way (28s vs 10s from the
+  // registry), the store added 3GB to the build context and the final
+  // image, and the build took 339s instead of 27s.
 
   // pnpm copies every workspace manifest into the image — as individual
   // COPY instructions that many layers exceed docker's depth limit, so
@@ -88,8 +90,6 @@ export const createNodeDockerJobDefinition = async (
 
   return {
     script: [
-      // the COPY source must exist even when the cache was cold
-      ...(copyPnpmStore ? ["mkdir -p .pnpm-store"] : []),
       ...(isPnpm
         ? [
             `tar -cf ${WORKSPACE_FILES_TAR} ${packageManagerInfo.pathsToCopyInDocker.join(" ")}`,
@@ -109,14 +109,10 @@ export const createNodeDockerJobDefinition = async (
             `ADD ${WORKSPACE_FILES_TAR} /app/`,
             // ADD does not apply --chown to extracted tars, and parent
             // dirs of the entries come out root-owned — fix ownership
-            // while the stage still runs as root (store not copied yet,
-            // so this only touches the small manifest tree). Custom
-            // base images without a node user run as root and don't
-            // need it, hence the fallback
+            // while the stage still runs as root (this only touches the
+            // small manifest tree). Custom base images without a node
+            // user run as root and don't need it, hence the fallback
             `RUN chown -R node:node /app || true`,
-            ...(copyPnpmStore
-              ? [`COPY --chown=node:node .pnpm-store /app/.pnpm-store`]
-              : []),
           ].join("\n")
         : packageManagerInfo.pathsToCopyInDocker
             .map((dir) => `COPY --chown=node:node ${dir} /app/${dir}`)

--- a/packages/pipeline/src/build/node/cache.ts
+++ b/packages/pipeline/src/build/node/cache.ts
@@ -6,10 +6,9 @@ import type { Context } from "../../types/context";
 import type { CacheConfig } from "../types";
 
 /**
- * stable reference between the two node caches: the package-manager
- * (yarn zip / pnpm store) cache declares itself redundant when the
- * node_modules cache scored an exact-lockfile hit (github skips the
- * ~0.6GB download on warm runs)
+ * stable reference between the two yarn caches: the zip cache declares
+ * itself redundant when the node_modules cache scored an exact-lockfile
+ * hit (github skips the ~0.6GB download on warm runs)
  */
 const NODE_MODULES_CACHE_ID = "node-modules";
 
@@ -38,39 +37,38 @@ const getCacheBaseDir = async (context: Context): Promise<string> => {
 };
 
 /**
- * the package manager's download cache: yarn's `.yarn` zip cache, or
- * pnpm's content-addressable store (which catladder points at a
- * project-local `.pnpm-store`, see the install script)
+ * the package manager's download cache: yarn's `.yarn` zip cache.
+ *
+ * pnpm gets nothing. Its store is a content-addressable tree of
+ * hundreds of thousands of small files, and moving it costs more than
+ * the install it saves: measured on a 3800-package monorepo, restoring
+ * the 1 GB store took ~53s on gitlab (which zips file by file) and
+ * ~23s on github, against a from-registry install of ~30-40s. See
+ * getNodeModulesCache for the node_modules half of the same finding.
  */
 export const getYarnCache = async (
   context: Context,
   policy = "pull-push",
 ): Promise<CacheConfig[]> => {
   const packageManagerInfo = await context.packageManagerInfo;
-  const isPnpm = packageManagerInfo.type === "pnpm";
+  if (packageManagerInfo.type === "pnpm") return [];
   const baseDir = await getCacheBaseDir(context);
-  // pnpm keeps its store in a format-versioned subdir (v10, v11, ...)
-  // and never cleans old ones up — scope the cache slot by major so a
-  // pnpm upgrade starts a fresh slot instead of dragging the dead old
-  // store tree along in every cache transfer (formats change only on
-  // majors)
-  const pnpmStoreKey = `pnpm-v${packageManagerInfo.version.split(".")[0]}`;
   return [
     {
       scope: "buildDir",
       pathMode: "relative",
       buildDir: baseDir,
-      key: isPnpm ? pnpmStoreKey : "yarn",
+      key: "yarn",
       policy,
-      paths: [isPnpm ? ".pnpm-store" : ".yarn"],
+      paths: [".yarn"],
       // content-key for immutable-cache backends (github); the lockfile
       // decides whether the cached content could have changed
-      keyFiles: [isPnpm ? "pnpm-lock.yaml" : "yarn.lock"],
-      // the package manager's download cache (~hundreds of MB) is only
-      // read when packages have to be (re)installed. When the
-      // node_modules cache hit for the same lockfile, install verifies
-      // its state file and never touches the store — so github skips
-      // downloading this cache entirely
+      keyFiles: ["yarn.lock"],
+      // the yarn zip cache (~hundreds of MB) is only read when packages
+      // have to be (re)installed. When the node_modules cache hit for
+      // the same lockfile, install verifies its state file and never
+      // touches the zips — so github skips downloading this cache
+      // entirely
       redundantOnExactHitOf: NODE_MODULES_CACHE_ID,
     },
   ];
@@ -83,13 +81,18 @@ export const getNodeModulesCache = async (
   const packageManagerInfo = await context.packageManagerInfo;
   const baseDir = await getCacheBaseDir(context);
 
-  const { workspaces } = packageManagerInfo;
-  const isPnpm = packageManagerInfo.type === "pnpm";
-  const lockFileName = isPnpm ? "pnpm-lock.yaml" : "yarn.lock";
-  // yarn berry tracks install state in .yarn/install-state.gz (pnpm's
-  // equivalent lives inside node_modules and is covered by the paths)
-  const hasInstallState =
-    packageManagerInfo.type === "yarn" && !packageManagerInfo.isClassic;
+  // pnpm gets no node_modules cache either: archiving the tree (root
+  // plus every workspace's symlink farm, >1GB in real monorepos) costs
+  // ~190s per saving job to spare ~6s of install, and a safe pnpm slot
+  // must be keyed by lockfile hash (a pnpm install over a node_modules
+  // from a different lockfile leaves orphaned .pnpm dirs that break
+  // type identity), so it misses on every dependency change anyway.
+  // pnpm projects run entirely uncached — see getYarnCache
+  if (packageManagerInfo.type === "pnpm") return [];
+
+  const lockFileName = "yarn.lock";
+  // yarn berry tracks install state in .yarn/install-state.gz
+  const hasInstallState = !packageManagerInfo.isClassic;
 
   // We intentionally do not use the contents of the lockfile as a cache key, as install should always guarantee that the files are updated, but it can still use part of the cache if not all packages are up-to-date.
   // It would slow down all pipelines whenever one adds a new dependency as it will need to download all node_modules again.
@@ -99,19 +102,7 @@ export const getNodeModulesCache = async (
       pathMode: "absolute",
 
       // we use the dirname, not the component name, because in certain cases we have two apps in the same directory and want to share the cache, e.g. when having storybook in the same package.json
-      //
-      // pnpm gets its own, lockfile-keyed cache: node_modules layouts
-      // are not compatible between package managers (a migrating
-      // project must not inherit the yarn slot), and unlike yarn, a
-      // pnpm install on top of a node_modules from a different lockfile
-      // leaves orphaned .pnpm dirs behind that break type identity —
-      // so the slot changes whenever the lockfile changes
-      key: isPnpm
-        ? {
-            prefix: "pnpm-" + slugify(baseDir) + "-node-modules",
-            files: [join(baseDir, "pnpm-lock.yaml")],
-          }
-        : slugify(baseDir) + "-node-modules",
+      key: slugify(baseDir) + "-node-modules",
       // content-key for immutable-cache backends (github); the lockfile
       // decides whether the cached content could have changed (absolute
       // pathMode: resolve the lockfile explicitly)
@@ -122,12 +113,6 @@ export const getNodeModulesCache = async (
       policy,
       paths: uniq([
         join(baseDir, "node_modules"),
-        // pnpm's per-package node_modules are symlink farms worth
-        // keeping warm (yarn hoists into the root, so root-only
-        // matches its historical behavior)
-        ...(isPnpm
-          ? workspaces.map((w) => join(w.location, "node_modules"))
-          : []),
         ...(hasInstallState ? [join(baseDir, ".yarn/install-state.gz")] : []),
       ]),
     },

--- a/packages/pipeline/src/build/node/packageManagerInstall.ts
+++ b/packages/pipeline/src/build/node/packageManagerInstall.ts
@@ -41,24 +41,17 @@ const getEnsurePnpmCommand = (version: string) =>
   `if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@${version}; fi`;
 
 /**
- * pnpm's store is global by default; point it at a project-local
- * directory so CI can cache it (the pnpm equivalent of the `.yarn`
- * zip cache). Passed as the --store-dir flag: pnpm 11 stopped reading
- * the npm_config_store_dir env var (settings only come from
- * pnpm-workspace.yaml / global config / CLI flags), the flag works on
- * v10 and v11
+ * pnpm jobs use pnpm's own (global, per-runner) store location. There
+ * used to be a `--store-dir` pointing at a project-local
+ * `.pnpm-store`, so CI could cache it — that cache is gone (see
+ * getYarnCache), and keeping the store inside the repo only meant it
+ * landed in docker build contexts.
  */
-const getPnpmStoreDirExpression = (inWorkspace: boolean) =>
-  inWorkspace
-    ? `"$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"`
-    : `"$PWD/.pnpm-store"`;
-
 const getPnpmInstallCommands = (
-  context: Context,
   packageManagerInfo: PackageManagerInfoBase & { type: "pnpm" },
 ) => [
   getEnsurePnpmCommand(packageManagerInfo.version),
-  `pnpm install --frozen-lockfile --store-dir ${getPnpmStoreDirExpression(isInWorkspace(context, packageManagerInfo))}`,
+  `pnpm install --frozen-lockfile`,
 ];
 
 export const DEFAULT_AUDIT_LEVEL: AuditLevel = "critical";
@@ -123,7 +116,7 @@ export const getPackageManagerInstall = async (
       ? collapseableSection(
           "pnpminstall",
           "pnpm install",
-        )(getPnpmInstallCommands(context, packageManagerInfo))
+        )(getPnpmInstallCommands(packageManagerInfo))
       : collapseableSection(
           "yarninstall",
           "Yarn install",
@@ -145,11 +138,12 @@ const DOCKER_COPY_FILES = `COPY --chown=node:node $APP_DIR .`;
 const getPnpmDockerAppCopyAndBuildScript = (
   packageManagerInfo: PackageManagerInfoComponent & { type: "pnpm" },
 ) => {
-  // the store was copied into the image (like the yarn zip cache), so
-  // the prod install links from it instead of hitting the registry
-  const storeDir = packageManagerInfo.componentIsInWorkspace
-    ? "/app/.pnpm-store"
-    : "/app/$APP_DIR/.pnpm-store";
+  // the prod install downloads from the registry: nothing is copied
+  // into the image to link from (see createNodeDockerJobDefinition).
+  // The store it fills is scratch space outside /app, dropped in the
+  // same layer so the packages ship once — node_modules holds
+  // hardlinks, so removing the store keeps the files alive
+  const storeDir = "/tmp/pnpm-store";
   // in a workspace, only install the component (and its workspace
   // dependencies) — the pnpm equivalent of `yarn workspaces focus`.
   // npm package names are shell-safe unquoted (the whole script is
@@ -163,7 +157,7 @@ const getPnpmDockerAppCopyAndBuildScript = (
     `
 ${DOCKER_COPY_FILES}
 RUN command -v pnpm >/dev/null 2>&1 || npm install -g pnpm@${packageManagerInfo.version}
-RUN pnpm install --prod --frozen-lockfile --store-dir ${storeDir}${filter}
+RUN pnpm install --prod --frozen-lockfile --store-dir ${storeDir}${filter} && rm -rf ${storeDir}
     `.trim(),
   );
 };

--- a/skills/catladder-migrate-package-manager/SKILL.md
+++ b/skills/catladder-migrate-package-manager/SKILL.md
@@ -40,9 +40,9 @@ change needed:
 
 | | yarn | pnpm |
 |---|---|---|
-| CI install | `yarn install --immutable` | `pnpm install --frozen-lockfile --store-dir …` |
-| download cache | `.yarn` zip cache | project-local `.pnpm-store`, cache slot scoped by pnpm major |
-| node_modules cache | mutable slot per build dir | **lockfile-keyed** slot (a pnpm install over a foreign tree leaves orphaned `.pnpm` dirs) |
+| CI install | `yarn install --immutable` | `pnpm install --frozen-lockfile` |
+| download cache | `.yarn` zip cache | **none** — installing from the registry is cheaper than moving the store |
+| node_modules cache | mutable slot per build dir | **none** (measured: the archive costs more than the install it saves) |
 | docker prod install | `yarn workspaces focus --production` | `pnpm install --prod --frozen-lockfile --filter <pkg>...` |
 | audit job | `yarn npm audit … --all --recursive` | `pnpm audit --prod --audit-level critical` |
 | build/start defaults | `yarn build` / `yarn start` | `pnpm build` / `pnpm start` |
@@ -146,9 +146,9 @@ skip it and run a bare `pnpm install` — that silently upgrades hundreds
 of transitive dependencies at the same time as the package manager
 changes, and you will not know which change broke what.
 
-Then set the `packageManager` field, and update `.gitignore`:
-`.pnpm-store/` in, `.yarn/*` entries out (keep `.yarn/patches` only if
-you left the patches there).
+Then set the `packageManager` field, and update `.gitignore`: `.yarn/*`
+entries out (keep `.yarn/patches` only if you left the patches there).
+Nothing pnpm-specific needs ignoring — the store lives outside the repo.
 
 ## Step 4 — fix the fallout locally
 
@@ -231,8 +231,8 @@ Mirrored, with one loss to state up front: **there is no importer back**.
 every range — the migration necessarily bumps transitive versions.
 Do it deliberately:
 
-1. Delete `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.pnpm-store`, and the
-   `node_modules` trees.
+1. Delete `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and the `node_modules`
+   trees.
 2. Move `packages:` back into package.json `workspaces`, `overrides` →
    `resolutions`, `patchedDependencies` → yarn's patch protocol,
    `allowBuilds` → (yarn runs build scripts by default; nothing needed).

--- a/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
+++ b/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
@@ -82,9 +82,26 @@ the docker build context.
 
 **Version drift in `--prod` installs.** `pnpm install --prod` on a
 node_modules tree from a *different* lockfile does not prune orphaned
-`.pnpm` directories. That is why catladder keys the pnpm node_modules
-cache by the lockfile instead of reusing a mutable slot — and why you
-should never reuse a yarn branch's cache for a pnpm branch.
+`.pnpm` directories — never reuse one branch's node_modules for another
+lockfile, and never a yarn tree for a pnpm branch.
+
+**Nothing is cached.** A yarn pipeline caches its zip cache and
+node_modules; a pnpm pipeline caches neither, and does not copy a store
+into docker images either. pnpm installs a 3800-package monorepo from
+the registry in 30-40s, which is less than it costs to move a 1 GB
+store or a 1.3 GB node_modules tree through a CI cache — measured
+side-by-side, caching made jobs about twice as slow on gitlab. Two
+consequences when migrating: CI pulls more from the registry than the
+yarn setup did (worth a registry proxy if that matters to you), and
+`.pnpm-store` should not appear anywhere in the repo or a build
+context.
+
+**Docker images must not carry the store.** If a store is copied into
+an image, it lands in a layer below `node_modules`, pnpm cannot hardlink
+across the overlay boundary, and every package is copied instead — the
+install gets *slower* (28s vs 10s from the registry) and the image
+carries the packages twice. Let the `--prod` install download, into a
+store outside the app directory that the same `RUN` layer deletes.
 
 **pnpm 11 needs node ≥ 22.13** (pnpm 10: ≥ 18.12), and it does not fail
 politely: it prints a `warn:` line and then crashes on

--- a/skills/catladder-pipelines/SKILL.md
+++ b/skills/catladder-pipelines/SKILL.md
@@ -58,12 +58,13 @@ the registry.
 
 ## Caching
 
-Cache configuration is generated per build type; node builds cache
-`node_modules` and the package manager's download cache (the `.yarn`
-zip cache, or for pnpm projects a project-local `.pnpm-store`). GitLab
-uses mutable caches with
-fallback keys (review branches fall back to the dev cache); GitHub uses
-immutable lockfile-keyed caches where only the build job writes.
+Cache configuration is generated per build type. **yarn** node builds
+cache `node_modules` and the `.yarn` zip cache; GitLab uses mutable
+caches with fallback keys (review branches fall back to the dev cache),
+GitHub immutable lockfile-keyed caches where only the build job writes.
+**pnpm** builds cache nothing: measured on a 3800-package monorepo,
+moving the store or node_modules through a CI cache costs more than
+pnpm's from-registry install.
 Caching behavior is changed via the build config in `catladder.ts`,
 not in the YAML.
 


### PR DESCRIPTION
## Why

Every pnpm caching mechanism catladder had lost its measurement. Each configuration below ran as jobs **in the same pipeline/run**, so they shared fleet conditions — an earlier cross-pipeline comparison was thrown away after the same job's cache throughput varied 3× between afternoons.

### node_modules cache — [gitlab 338067](https://git.panter.ch/manul/wea/food-2050/-/pipelines/338067)

| | restore | install | save | total |
|---|---|---|---|---|
| with node_modules cache (hit) | 169s | 6.4s | 1s | **176s** |
| store-only | 44s | 12.8s | 1s | **57s** |
| writer (hit + save) | 182s | 8.2s | 187s | **377s** |

1.29 GB / 348k files to save 6s of install.

### store cache — [gitlab 338153](https://git.panter.ch/manul/wea/food-2050/-/pipelines/338153) / [github](https://github.com/panter/food-2050-catladder-test/actions/runs/31539879149)

| | GitLab | GitHub |
|---|---|---|
| no cache at all | **35s / 50s** | 64s / 65s |
| store cache (hit) | 74s / 76s | **56s / 65s** |
| — restore | 53s / 54s | 21s / 25s |
| — install | 16.2s / 16.4s | 28s / 32s |

GitLab zips the store file by file (53s for 186k files); GitHub streams one zstd tarball (21-25s). Two effects compound on GitLab: slow cache transport *and* faster runners, so a cold install (30-42s) beats a warm restore.

### store inside docker images — [github](https://github.com/panter/food-2050-catladder-test/actions/runs/31543067266)

| | store copied in | no store | no store + in-layer rm |
|---|---|---|---|
| docker build | 339s / 146s | 27s | **25s** |
| in-image `--prod` install | 28.4s (`reused 441`) | **9.6s** (`downloaded 442`) | 10.8s |
| final image | **3.35 GB** | 0.73 GB | **0.66 GB** |

The store lands in a layer *below* `node_modules`, so pnpm cannot hardlink across the overlay boundary and copies every package — making the install slower than downloading it, while shipping the payload twice in a single-stage image.

## What

- `getYarnCache` / `getNodeModulesCache` return nothing for pnpm — pnpm projects generate no `cache:` blocks at all
- jobs install with plain `pnpm install --frozen-lockfile`; the `--store-dir` pointing at a project-local `.pnpm-store` is gone (nothing to cache, and nothing to leak into a docker context)
- the docker job no longer does `mkdir -p .pnpm-store` or `COPY .pnpm-store /app/.pnpm-store`
- the in-image prod install uses `--store-dir /tmp/pnpm-store` and `rm -rf`s it in the same `RUN`, so packages ship once
- yarn caching byte-identical

## Trade-off

CI now pulls dependencies from the registry on every install job (~50 per food-2050 pipeline). Worth a registry proxy if that load matters; it buys back roughly 2 minutes per reader job, 5 per writer, and ~2.7 GB per image.

## Verification

- 278 tests green; only the two pnpm example snapshots changed
- the store removal is validated in a real image: `node_modules` reads back identically to the store-copying variant (same 3000 files / 136,828,468 bytes, 0 unreadable, `@node-rs/argon2` natives present)