### PR TITLE
chore: regenerate own pipeline for the uncached pnpm builds

### DIFF
--- a/.catladder-generated/github/scripts/docs-deploy-dev.sh
+++ b/.catladder-generated/github/scripts/docs-deploy-dev.sh
@@ -46,7 +46,7 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm --filter docs gen-md
 pnpm --filter docs build

--- a/.catladder-generated/github/scripts/ws-base-app-dev.sh
+++ b/.catladder-generated/github/scripts/ws-base-app-dev.sh
@@ -39,6 +39,6 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build

--- a/.catladder-generated/github/scripts/ws-base-app-prod.sh
+++ b/.catladder-generated/github/scripts/ws-base-app-prod.sh
@@ -39,6 +39,6 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build

--- a/.catladder-generated/github/scripts/ws-base-app-review.sh
+++ b/.catladder-generated/github/scripts/ws-base-app-review.sh
@@ -39,6 +39,6 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm build

--- a/.catladder-generated/github/scripts/ws-base-lint-dev.sh
+++ b/.catladder-generated/github/scripts/ws-base-lint-dev.sh
@@ -40,6 +40,6 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm lint

--- a/.catladder-generated/github/scripts/ws-base-lint-review.sh
+++ b/.catladder-generated/github/scripts/ws-base-lint-review.sh
@@ -40,6 +40,6 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm lint

--- a/.catladder-generated/github/scripts/ws-base-test-dev.sh
+++ b/.catladder-generated/github/scripts/ws-base-test-dev.sh
@@ -40,6 +40,6 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm test

--- a/.catladder-generated/github/scripts/ws-base-test-review.sh
+++ b/.catladder-generated/github/scripts/ws-base-test-review.sh
@@ -40,6 +40,6 @@ if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
 collapseable_section_end "nodeinstall"
 collapseable_section_start "pnpminstall" "pnpm install"
 if ! command -v pnpm &> /dev/null; then corepack enable pnpm 2>/dev/null || npm install -g pnpm@11.20.0; fi
-pnpm install --frozen-lockfile --store-dir "$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.pnpm-store"
+pnpm install --frozen-lockfile
 collapseable_section_end "pnpminstall"
 pnpm test

--- a/.claude/skills/catladder-migrate-package-manager/SKILL.md
+++ b/.claude/skills/catladder-migrate-package-manager/SKILL.md
@@ -42,9 +42,9 @@ change needed:
 
 | | yarn | pnpm |
 |---|---|---|
-| CI install | `yarn install --immutable` | `pnpm install --frozen-lockfile --store-dir …` |
-| download cache | `.yarn` zip cache | project-local `.pnpm-store`, cache slot scoped by pnpm major |
-| node_modules cache | mutable slot per build dir | **lockfile-keyed** slot (a pnpm install over a foreign tree leaves orphaned `.pnpm` dirs) |
+| CI install | `yarn install --immutable` | `pnpm install --frozen-lockfile` |
+| download cache | `.yarn` zip cache | **none** — installing from the registry is cheaper than moving the store |
+| node_modules cache | mutable slot per build dir | **none** (measured: the archive costs more than the install it saves) |
 | docker prod install | `yarn workspaces focus --production` | `pnpm install --prod --frozen-lockfile --filter <pkg>...` |
 | audit job | `yarn npm audit … --all --recursive` | `pnpm audit --prod --audit-level critical` |
 | build/start defaults | `yarn build` / `yarn start` | `pnpm build` / `pnpm start` |
@@ -148,9 +148,9 @@ skip it and run a bare `pnpm install` — that silently upgrades hundreds
 of transitive dependencies at the same time as the package manager
 changes, and you will not know which change broke what.
 
-Then set the `packageManager` field, and update `.gitignore`:
-`.pnpm-store/` in, `.yarn/*` entries out (keep `.yarn/patches` only if
-you left the patches there).
+Then set the `packageManager` field, and update `.gitignore`: `.yarn/*`
+entries out (keep `.yarn/patches` only if you left the patches there).
+Nothing pnpm-specific needs ignoring — the store lives outside the repo.
 
 ## Step 4 — fix the fallout locally
 
@@ -233,8 +233,8 @@ Mirrored, with one loss to state up front: **there is no importer back**.
 every range — the migration necessarily bumps transitive versions.
 Do it deliberately:
 
-1. Delete `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `.pnpm-store`, and the
-   `node_modules` trees.
+1. Delete `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and the `node_modules`
+   trees.
 2. Move `packages:` back into package.json `workspaces`, `overrides` →
    `resolutions`, `patchedDependencies` → yarn's patch protocol,
    `allowBuilds` → (yarn runs build scripts by default; nothing needed).

--- a/.claude/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
+++ b/.claude/skills/catladder-migrate-package-manager/references/yarn-to-pnpm-differences.md
@@ -84,9 +84,26 @@ the docker build context.
 
 **Version drift in `--prod` installs.** `pnpm install --prod` on a
 node_modules tree from a *different* lockfile does not prune orphaned
-`.pnpm` directories. That is why catladder keys the pnpm node_modules
-cache by the lockfile instead of reusing a mutable slot — and why you
-should never reuse a yarn branch's cache for a pnpm branch.
+`.pnpm` directories — never reuse one branch's node_modules for another
+lockfile, and never a yarn tree for a pnpm branch.
+
+**Nothing is cached.** A yarn pipeline caches its zip cache and
+node_modules; a pnpm pipeline caches neither, and does not copy a store
+into docker images either. pnpm installs a 3800-package monorepo from
+the registry in 30-40s, which is less than it costs to move a 1 GB
+store or a 1.3 GB node_modules tree through a CI cache — measured
+side-by-side, caching made jobs about twice as slow on gitlab. Two
+consequences when migrating: CI pulls more from the registry than the
+yarn setup did (worth a registry proxy if that matters to you), and
+`.pnpm-store` should not appear anywhere in the repo or a build
+context.
+
+**Docker images must not carry the store.** If a store is copied into
+an image, it lands in a layer below `node_modules`, pnpm cannot hardlink
+across the overlay boundary, and every package is copied instead — the
+install gets *slower* (28s vs 10s from the registry) and the image
+carries the packages twice. Let the `--prod` install download, into a
+store outside the app directory that the same `RUN` layer deletes.
 
 **pnpm 11 needs node ≥ 22.13** (pnpm 10: ≥ 18.12), and it does not fail
 politely: it prints a `warn:` line and then crashes on

--- a/.claude/skills/catladder-pipelines/SKILL.md
+++ b/.claude/skills/catladder-pipelines/SKILL.md
@@ -60,12 +60,13 @@ the registry.
 
 ## Caching
 
-Cache configuration is generated per build type; node builds cache
-`node_modules` and the package manager's download cache (the `.yarn`
-zip cache, or for pnpm projects a project-local `.pnpm-store`). GitLab
-uses mutable caches with
-fallback keys (review branches fall back to the dev cache); GitHub uses
-immutable lockfile-keyed caches where only the build job writes.
+Cache configuration is generated per build type. **yarn** node builds
+cache `node_modules` and the `.yarn` zip cache; GitLab uses mutable
+caches with fallback keys (review branches fall back to the dev cache),
+GitHub immutable lockfile-keyed caches where only the build job writes.
+**pnpm** builds cache nothing: measured on a 3800-package monorepo,
+moving the store or node_modules through a CI cache costs more than
+pnpm's from-registry install.
 Caching behavior is changed via the build config in `catladder.ts`,
 not in the YAML.
 

--- a/.github/workflows/catladder-main.yml
+++ b/.github/workflows/catladder-main.yml
@@ -203,25 +203,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache pnpm-.-node-modules
-        id: cache-node-modules
-        uses: actions/cache/restore@v4
-        with:
-          path: |-
-            node_modules
-            apps/cli/node_modules
-            apps/docs/node_modules
-            packages/bash/node_modules
-            packages/pipeline/node_modules
-          key: pnpm-.-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-.-node-modules-
-      - name: Cache .-pnpm-v11
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        uses: actions/cache/restore@v4
-        with:
-          path: .pnpm-store
-          key: .-pnpm-v11-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: .-pnpm-v11-
       - name: 👮 lint
         id: main
         run: bash .catladder-generated/github/scripts/ws-base-lint-dev.sh
@@ -241,25 +222,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache pnpm-.-node-modules
-        id: cache-node-modules
-        uses: actions/cache/restore@v4
-        with:
-          path: |-
-            node_modules
-            apps/cli/node_modules
-            apps/docs/node_modules
-            packages/bash/node_modules
-            packages/pipeline/node_modules
-          key: pnpm-.-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-.-node-modules-
-      - name: Cache .-pnpm-v11
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        uses: actions/cache/restore@v4
-        with:
-          path: .pnpm-store
-          key: .-pnpm-v11-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: .-pnpm-v11-
       - name: 🧪 test
         id: main
         run: bash .catladder-generated/github/scripts/ws-base-test-dev.sh
@@ -280,25 +242,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache pnpm-.-node-modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: |-
-            node_modules
-            apps/cli/node_modules
-            apps/docs/node_modules
-            packages/bash/node_modules
-            packages/pipeline/node_modules
-          key: pnpm-.-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-.-node-modules-
-      - name: Cache .-pnpm-v11
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: .pnpm-store
-          key: .-pnpm-v11-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: .-pnpm-v11-
       - name: 🔨 app
         id: main
         run: bash .catladder-generated/github/scripts/ws-base-app-dev.sh

--- a/.github/workflows/catladder-release.yml
+++ b/.github/workflows/catladder-release.yml
@@ -185,25 +185,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache pnpm-.-node-modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: |-
-            node_modules
-            apps/cli/node_modules
-            apps/docs/node_modules
-            packages/bash/node_modules
-            packages/pipeline/node_modules
-          key: pnpm-.-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-.-node-modules-
-      - name: Cache .-pnpm-v11
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: .pnpm-store
-          key: .-pnpm-v11-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: .-pnpm-v11-
       - name: 🔨 app
         id: main
         run: bash .catladder-generated/github/scripts/ws-base-app-prod.sh

--- a/.github/workflows/catladder-review.yml
+++ b/.github/workflows/catladder-review.yml
@@ -208,25 +208,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache pnpm-.-node-modules
-        id: cache-node-modules
-        uses: actions/cache/restore@v4
-        with:
-          path: |-
-            node_modules
-            apps/cli/node_modules
-            apps/docs/node_modules
-            packages/bash/node_modules
-            packages/pipeline/node_modules
-          key: pnpm-.-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-.-node-modules-
-      - name: Cache .-pnpm-v11
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        uses: actions/cache/restore@v4
-        with:
-          path: .pnpm-store
-          key: .-pnpm-v11-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: .-pnpm-v11-
       - name: 👮 lint
         id: main
         run: bash .catladder-generated/github/scripts/ws-base-lint-review.sh
@@ -246,25 +227,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache pnpm-.-node-modules
-        id: cache-node-modules
-        uses: actions/cache/restore@v4
-        with:
-          path: |-
-            node_modules
-            apps/cli/node_modules
-            apps/docs/node_modules
-            packages/bash/node_modules
-            packages/pipeline/node_modules
-          key: pnpm-.-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-.-node-modules-
-      - name: Cache .-pnpm-v11
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        uses: actions/cache/restore@v4
-        with:
-          path: .pnpm-store
-          key: .-pnpm-v11-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: .-pnpm-v11-
       - name: 🧪 test
         id: main
         run: bash .catladder-generated/github/scripts/ws-base-test-review.sh
@@ -285,25 +247,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Cache pnpm-.-node-modules
-        id: cache-node-modules
-        uses: actions/cache@v4
-        with:
-          path: |-
-            node_modules
-            apps/cli/node_modules
-            apps/docs/node_modules
-            packages/bash/node_modules
-            packages/pipeline/node_modules
-          key: pnpm-.-node-modules-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: pnpm-.-node-modules-
-      - name: Cache .-pnpm-v11
-        if: ${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: .pnpm-store
-          key: .-pnpm-v11-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: .-pnpm-v11-
       - name: 🔨 app
         id: main
         run: bash .catladder-generated/github/scripts/ws-base-app-review.sh


### PR DESCRIPTION
Follow-up to #18, which changed the generator but not the generated output that catladder itself runs on — so the jobs in [this run](https://github.com/panter/catladder/actions/runs/31543758866/job/93951745585) were still restoring `pnpm-.-node-modules` and `.-pnpm-v11`.

Regenerated with `pnpm catenv`:
- all pnpm cache steps gone from the three workflows (−133 lines)
- job scripts install with plain `pnpm install --frozen-lockfile` (no `--store-dir`)
- shipped skill copies under `.claude/skills` re-materialized to match the sources edited in #18

Generated-output only; no source changes.