### PR TITLE
fix(changesets): name the project's package manager in the changeset hint

### DIFF
--- a/.changeset/changeset-hint-package-manager.md
+++ b/.changeset/changeset-hint-package-manager.md
@@ -1,0 +1,8 @@
+---
+"catladder": patch
+---
+
+The changeset check's "how to add one" hint now names the project's own
+package manager, instead of always saying `yarn changeset` — which does
+not exist in a pnpm project. Same for the release job's "nothing to
+release" message.

--- a/apps/cli/src/release/__tests__/changesetCheck.test.ts
+++ b/apps/cli/src/release/__tests__/changesetCheck.test.ts
@@ -15,6 +15,7 @@ describe("runChangesetCheck", () => {
       pending: [changeset("minor", "Add the fancy dashboard")],
       lastTag: "v4.7.0",
       requestLabel: "merge request",
+      packageManager: "yarn",
     });
     expect(result.addsChangeset).toBe(true);
     expect(result.markdown).toContain(CHANGESET_CHECK_MARKER);
@@ -31,6 +32,7 @@ describe("runChangesetCheck", () => {
       pending: [],
       lastTag: "v4.7.0",
       requestLabel: "merge request",
+      packageManager: "yarn",
     });
     expect(result.addsChangeset).toBe(false);
     expect(result.markdown).toContain(
@@ -48,11 +50,26 @@ describe("runChangesetCheck", () => {
       ],
       lastTag: "v4.7.0",
       requestLabel: "merge request",
+      packageManager: "yarn",
     });
     expect(result.addsChangeset).toBe(false);
     expect(result.markdown).toContain("2 changesets are pending");
     expect(result.markdown).toContain("**v5.0.0**");
     expect(result.markdown).toContain("Remove the legacy mode");
+  });
+
+  it("names the project's own package manager in the how-to hint", () => {
+    const forPm = (packageManager: "yarn" | "pnpm") =>
+      runChangesetCheck({
+        addedFiles: [],
+        pending: [],
+        lastTag: "v4.7.0",
+        requestLabel: "merge request",
+        packageManager,
+      }).markdown;
+    expect(forPm("pnpm")).toContain("`pnpm changeset`");
+    expect(forPm("pnpm")).not.toContain("yarn");
+    expect(forPm("yarn")).toContain("`yarn changeset`");
   });
 
   it("handles the first release (no previous tag)", () => {
@@ -61,6 +78,7 @@ describe("runChangesetCheck", () => {
       pending: [changeset("minor", "Initial feature")],
       lastTag: null,
       requestLabel: "pull request",
+      packageManager: "yarn",
     });
     expect(result.markdown).toContain("✅ This pull request adds 1 changeset");
     expect(result.markdown).toContain("**v1.0.0**");

--- a/apps/cli/src/release/changesetCheck.ts
+++ b/apps/cli/src/release/changesetCheck.ts
@@ -28,6 +28,11 @@ export type ChangesetCheckInput = {
   lastTag: string | null;
   /** platform wording: "merge request" (gitlab) or "pull request" (github) */
   requestLabel: string;
+  /**
+   * the project's package manager, so the "how to add one" hint names a
+   * command that actually exists there
+   */
+  packageManager: "yarn" | "pnpm";
 };
 
 export type ChangesetCheckResult = {
@@ -42,6 +47,7 @@ export const runChangesetCheck = ({
   pending,
   lastTag,
   requestLabel,
+  packageManager,
 }: ChangesetCheckInput): ChangesetCheckResult => {
   const addsChangeset = addedFiles.length > 0;
 
@@ -53,7 +59,7 @@ export const runChangesetCheck = ({
     );
   } else {
     lines.push(
-      `⚠️ **This ${requestLabel} adds no changeset.** If the change is user-facing it will be missing from the next release's changelog — add \`.changeset/<name>.md\` (or run \`yarn changeset\`). For docs/chore changes this warning can be ignored.`,
+      `⚠️ **This ${requestLabel} adds no changeset.** If the change is user-facing it will be missing from the next release's changelog — add \`.changeset/<name>.md\` (or run \`${packageManager} changeset\`). For docs/chore changes this warning can be ignored.`,
     );
   }
   lines.push("");

--- a/apps/cli/src/release/changesetCheckJob.ts
+++ b/apps/cli/src/release/changesetCheckJob.ts
@@ -7,6 +7,7 @@
  * sticky MR/PR comment where a token allows it. Exits 1 (the job runs
  * with allow_failure) when the merge request adds no changeset.
  */
+import { existsSync } from "fs";
 import { writeFile } from "fs/promises";
 import { CHANGESET_CHECK_MARKER, runChangesetCheck } from "./changesetCheck";
 import { readPendingChangesets } from "./changesetsReleaseJob";
@@ -16,6 +17,13 @@ import { appendStepSummary } from "./stepSummary";
 export const CHANGESET_REPORT_FILE = "changeset-report.md";
 
 const onGithub = () => process.env.GITHUB_ACTIONS === "true";
+
+/**
+ * the repo's package manager, from the lockfile in the checkout — the
+ * hint for adding a changeset should name a command the project has
+ */
+const detectPackageManager = (): "yarn" | "pnpm" =>
+  existsSync("pnpm-lock.yaml") ? "pnpm" : "yarn";
 
 /**
  * the changeset files added by this merge request: diffed against the
@@ -172,6 +180,7 @@ export const changesetCheckJob = async () => {
     pending,
     lastTag,
     requestLabel: onGithub() ? "pull request" : "merge request",
+    packageManager: detectPackageManager(),
   });
 
   console.log(result.markdown.replace(`${CHANGESET_CHECK_MARKER}\n`, ""));

--- a/apps/cli/src/release/changesetsReleaseJob.ts
+++ b/apps/cli/src/release/changesetsReleaseJob.ts
@@ -5,6 +5,7 @@
  * from the last `v*` tag, writes the changelog, commits, tags and
  * pushes — the pushed tag triggers the taggedRelease pipeline.
  */
+import { existsSync } from "fs";
 import { readFile, readdir, rm, writeFile } from "fs/promises";
 import { join } from "path";
 import type { Changeset } from "./changesets";
@@ -145,7 +146,7 @@ export const changesetsReleaseJob = async () => {
       `no changesets found in ${CHANGESET_DIR}/ — nothing to release`,
     );
     console.log(
-      "add one with `yarn changeset` (or write .changeset/<name>.md by hand) and merge it to release",
+      `add one with \`${existsSync("pnpm-lock.yaml") ? "pnpm" : "yarn"} changeset\` (or write .changeset/<name>.md by hand) and merge it to release`,
     );
     console.log(
       "to release anyway (patch bump), run the force release job instead",


### PR DESCRIPTION
Spotted in a live food-2050 pipeline: the 🦋 changeset check told a pnpm repo to run `yarn changeset`.

The hint (and the release job's "nothing to release" message) now names the package manager detected from the lockfile in the checkout. Adds a test asserting a pnpm project's report mentions no yarn at all.