### PR TITLE
docs(site): show the catladder logo in the homepage hero

### DIFF
--- a/apps/docs/src/pages/index.module.css
+++ b/apps/docs/src/pages/index.module.css
@@ -16,6 +16,21 @@
   }
 }
 
+/* the logo is a solid black silhouette — recolor it to the hero's white text */
+.heroLogo {
+  display: block;
+  width: auto;
+  height: 8rem;
+  margin: 0 auto 1.5rem;
+  filter: brightness(0) invert(1);
+}
+
+@media screen and (max-width: 996px) {
+  .heroLogo {
+    height: 6rem;
+  }
+}
+
 .heroText {
   max-width: 46rem;
   margin: 0 auto 2rem;

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import CodeBlock from "@theme/CodeBlock";
@@ -33,6 +34,13 @@ function HomepageHeader() {
   return (
     <header className={clsx("hero hero--primary", styles.heroBanner)}>
       <div className="container">
+        <img
+          className={styles.heroLogo}
+          src={useBaseUrl("img/cat_ladder_logo.svg")}
+          alt=""
+          width={277}
+          height={221}
+        />
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
         </Heading>


### PR DESCRIPTION
The docs homepage hero led with the title text only. This renders the existing `static/img/cat_ladder_logo.svg` above it.

- Resolved through `useBaseUrl` so it works under the `/catladder/` base path on GitHub Pages.
- The asset is a solid black silhouette and the hero background is the primary green, so it is recolored to the hero's white text with `filter: brightness(0) invert(1)` — works in both light and dark mode.
- `alt=""`: the "CatLadder" title sits directly below, so a duplicate label would only add noise for screen readers. Intrinsic `width`/`height` are set to avoid layout shift; CSS drives the rendered height (8rem, 6rem below 996px).

No changeset — docs-site-only change, nothing published changes.

## Verification

Checked locally against `docusaurus start` in both light and dark mode: the white cat + ladder renders centered above the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)