### PR TITLE
fix(release): create the release entry on the git host

### DIFF
--- a/.changeset/changesets-release-entry.md
+++ b/.changeset/changesets-release-entry.md
@@ -1,0 +1,5 @@
+---
+"catladder": patch
+---
+
+Changesets releases now create the release entry on the git host (gitlab `/-/releases`, github `/releases`) with the changelog as its description — previously only the tag was pushed, so the releases page stayed empty (on the semantic-release path `@semantic-release/gitlab` did this). The api call never fails the job: the commit and tag are already pushed when it runs, so a missing token only warns.

--- a/.changeset/semantic-release-github-release-entry.md
+++ b/.changeset/semantic-release-github-release-entry.md
@@ -1,0 +1,5 @@
+---
+"catladder": patch
+---
+
+`semantic-release` on the github backend now creates the entry on the releases page too, via `@semantic-release/github` (the counterpart of the gitlab publish plugin, which is gitlab-only — on github the release used to end at the tag). Only the release is created: commenting on released pull requests/issues and labelling them stays off, so the release job keeps its `contents: write`-only permissions. Projects with their own `.releaserc` are unaffected, as before.

--- a/apps/cli/src/release/__tests__/releaseEntry.test.ts
+++ b/apps/cli/src/release/__tests__/releaseEntry.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createReleaseEntry } from "../releaseEntry";
+
+const gitlabEnv = {
+  GITHUB_ACTIONS: undefined,
+  GL_TOKEN: "glpat-token",
+  CI_API_V4_URL: "https://git.example.com/api/v4",
+  CI_PROJECT_ID: "42",
+};
+
+const githubEnv = {
+  GITHUB_ACTIONS: "true",
+  GITHUB_TOKEN: "gh-token",
+  GITHUB_REPOSITORY: "panter/catladder",
+};
+
+const stubEnv = (env: Record<string, string | undefined>) => {
+  Object.entries(env).forEach(([key, value]) => vi.stubEnv(key, value as any));
+};
+
+const stubFetch = (response: Partial<Response> = {}) => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 201,
+    text: async () => "",
+    ...response,
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("createReleaseEntry", () => {
+  it("creates the gitlab release for the pushed tag", async () => {
+    stubEnv(gitlabEnv);
+    const fetchMock = stubFetch();
+
+    await createReleaseEntry("v1.2.0", "- Add the export endpoint");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://git.example.com/api/v4/projects/42/releases");
+    expect(init.method).toBe("POST");
+    expect(init.headers["PRIVATE-TOKEN"]).toBe("glpat-token");
+    expect(JSON.parse(init.body)).toEqual({
+      tag_name: "v1.2.0",
+      description: "- Add the export endpoint",
+    });
+  });
+
+  it("creates the github release for the pushed tag", async () => {
+    stubEnv(githubEnv);
+    const fetchMock = stubFetch();
+
+    await createReleaseEntry("v1.2.0", "- Add the export endpoint");
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.github.com/repos/panter/catladder/releases");
+    expect(init.headers.authorization).toBe("Bearer gh-token");
+    expect(JSON.parse(init.body)).toEqual({
+      tag_name: "v1.2.0",
+      name: "v1.2.0",
+      body: "- Add the export endpoint",
+    });
+  });
+
+  it("does not throw when the api call fails — the tag is already pushed", async () => {
+    stubEnv(gitlabEnv);
+    stubFetch({ ok: false, status: 403, text: async () => "forbidden" });
+
+    await expect(
+      createReleaseEntry("v1.2.0", "- notes"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips without api context instead of failing the release", async () => {
+    stubEnv({ ...gitlabEnv, GL_TOKEN: undefined });
+    const fetchMock = stubFetch();
+
+    await createReleaseEntry("v1.2.0", "- notes");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/release/changesetsReleaseJob.ts
+++ b/apps/cli/src/release/changesetsReleaseJob.ts
@@ -23,6 +23,7 @@ import {
   git,
   gitWithEnv,
 } from "./releaseGit";
+import { createReleaseEntry } from "./releaseEntry";
 import { appendStepSummary } from "./stepSummary";
 
 const CHANGESET_DIR = ".changeset";
@@ -276,6 +277,8 @@ export const changesetsReleaseJob = async () => {
   await pushCommitAndTag(tag);
   console.log(`released ${tag}`);
   appendStepSummary(`🚀 **Released ${tag}**\n\n${entries}`);
+  // the tag alone creates no entry on the releases page of the git host
+  await createReleaseEntry(tag, entries);
 
   if (process.env.GITHUB_ACTIONS === "true") {
     await dispatchTaggedReleaseWorkflow(tag);

--- a/apps/cli/src/release/releaseEntry.ts
+++ b/apps/cli/src/release/releaseEntry.ts
@@ -1,0 +1,86 @@
+/**
+ * the release entry on the git host — gitlab's `/-/releases`, github's
+ * `/releases`. Pushing a tag does NOT create one: on the
+ * semantic-release path `@semantic-release/gitlab` used to do it, the
+ * changesets path creates it here (on both backends).
+ *
+ * Never fatal: when this runs, the release commit and tag are already
+ * pushed and the taggedRelease pipeline is on its way — a failing api
+ * call must not turn a done release into a red job (and a rerun would
+ * fail on the existing tag).
+ */
+
+const post = async (
+  url: string,
+  headers: Record<string, string>,
+  body: unknown,
+) => {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `POST ${url} failed: ${response.status} ${await response.text()}`,
+    );
+  }
+};
+
+/**
+ * GL_TOKEN is the project access token the release push already used,
+ * so its api scope is available here too
+ */
+const createGitlabReleaseEntry = async (tag: string, notes: string) => {
+  const token = process.env.GL_TOKEN;
+  const apiUrl = process.env.CI_API_V4_URL;
+  const projectId = process.env.CI_PROJECT_ID;
+  if (!token || !apiUrl || !projectId) {
+    console.warn(
+      "no GL_TOKEN / gitlab api context — skipping the release entry (the tag is pushed)",
+    );
+    return;
+  }
+  await post(
+    `${apiUrl}/projects/${projectId}/releases`,
+    { "PRIVATE-TOKEN": token },
+    // name defaults to the tag on gitlab
+    { tag_name: tag, description: notes },
+  );
+  console.log(`created the gitlab release entry for ${tag}`);
+};
+
+/** the workflow token, granted `contents: write` by the release job */
+const createGithubReleaseEntry = async (tag: string, notes: string) => {
+  const token = process.env.GITHUB_TOKEN;
+  const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository) {
+    console.warn(
+      "no GITHUB_TOKEN / repository context — skipping the release entry (the tag is pushed)",
+    );
+    return;
+  }
+  await post(
+    `${apiUrl}/repos/${repository}/releases`,
+    { authorization: `Bearer ${token}`, accept: "application/vnd.github+json" },
+    { tag_name: tag, name: tag, body: notes },
+  );
+  console.log(`created the github release entry for ${tag}`);
+};
+
+export const createReleaseEntry = async (tag: string, notes: string) => {
+  try {
+    if (process.env.GITHUB_ACTIONS === "true") {
+      await createGithubReleaseEntry(tag, notes);
+    } else {
+      await createGitlabReleaseEntry(tag, notes);
+    }
+  } catch (error) {
+    console.warn(
+      `⚠️ could not create the release entry for ${tag}: ${error}\n` +
+        "the release itself is done (commit, tag and changelog are pushed) — " +
+        "create the entry by hand if you need it",
+    );
+  }
+};

--- a/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/automatic-releases.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for automatic-releases github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -244,16 +244,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -465,7 +465,7 @@ catladder-main.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -646,16 +646,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1036,16 +1036,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1311,16 +1311,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1522,16 +1522,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1793,16 +1793,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3284,16 +3284,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3406,7 +3406,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a3
     - semanticRelease
   after_script: &a4
@@ -3426,7 +3426,7 @@ create release:
       allow_failure: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a3
   after_script: *a4
   rules:

--- a/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-execute-script-on-deploy.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-execute-script-on-deploy github workflow
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-stop-review:
@@ -1545,16 +1545,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-app-prod:
@@ -1816,16 +1816,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-stop-dev:
@@ -3321,16 +3321,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3443,7 +3443,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3462,7 +3462,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3483,7 +3483,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-existing-image.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-existing-image.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-existing-image github workflows YAML 1`]
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -196,16 +196,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-deploy-dev:
@@ -280,16 +280,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-deploy-review:
@@ -376,16 +376,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-deploy-stage:
@@ -466,16 +466,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -577,16 +577,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-deploy-prod:
@@ -663,16 +663,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -1352,16 +1352,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -1384,7 +1384,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a6
@@ -1403,7 +1403,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a4
     - semanticRelease
   after_script: &a5
@@ -1424,7 +1424,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a4
   after_script: *a5
   rules: *a6

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-defaults.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-health-check-defaults github workflows Y
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check-only-startup.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-health-check-only-startup github workflo
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-health-check.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-health-check github workflows YAML 1`] =
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-http2.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-http2 github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-llama.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-llama.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-llama github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -196,16 +196,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     llm-deploy-dev:
@@ -281,16 +281,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     llm-deploy-review:
@@ -378,16 +378,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     llm-deploy-stage:
@@ -469,16 +469,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     llm-stop-review:
@@ -581,16 +581,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     llm-deploy-prod:
@@ -668,16 +668,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     llm-stop-dev:
@@ -1372,16 +1372,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -1404,7 +1404,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a6
@@ -1423,7 +1423,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a4
     - semanticRelease
   after_script: &a5
@@ -1444,7 +1444,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a4
   after_script: *a5
   rules: *a6

--- a/packages/pipeline/examples/__snapshots__/cloud-run-long-service-name.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-long-service-name.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-long-service-name github workflows YAML 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     recipe-processing-service-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     recipe-processing-service-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     recipe-processing-service-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     recipe-processing-service-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     recipe-processing-service-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     recipe-processing-service-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-memory-limit.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-memory-limit github workflows YAML 1`] =
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-meteor-with-worker.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-meteor-with-worker github workflows YAML
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -346,16 +346,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-audit-dev:
@@ -770,16 +770,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-audit-review:
@@ -1214,16 +1214,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-app-stage:
@@ -1542,16 +1542,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-stop-review:
@@ -1804,16 +1804,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-app-prod:
@@ -2128,16 +2128,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-stop-dev:
@@ -3602,16 +3602,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3772,7 +3772,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3791,7 +3791,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3812,7 +3812,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-n8n.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-n8n.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-n8n github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -196,16 +196,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     n8n-deploy-dev:
@@ -282,16 +282,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     n8n-deploy-review:
@@ -380,16 +380,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     n8n-deploy-stage:
@@ -472,16 +472,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     n8n-stop-review:
@@ -600,16 +600,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     n8n-deploy-prod:
@@ -688,16 +688,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     n8n-stop-dev:
@@ -1663,16 +1663,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -1695,7 +1695,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a6
@@ -1714,7 +1714,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a4
     - semanticRelease
   after_script: &a5
@@ -1735,7 +1735,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a4
   after_script: *a5
   rules: *a6

--- a/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-nextjs.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-nextjs github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -673,16 +673,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1069,16 +1069,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1350,16 +1350,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1561,16 +1561,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1838,16 +1838,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3329,16 +3329,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3451,7 +3451,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3470,7 +3470,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3491,7 +3491,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-cpu-throttling.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-no-cpu-throttling github workflows YAML 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-no-service.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-no-service github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1545,16 +1545,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1816,16 +1816,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3405,16 +3405,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3527,7 +3527,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3546,7 +3546,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3567,7 +3567,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-non-public.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-non-public github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-post-stop-job.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-post-stop-job github workflows YAML 1`] 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1546,16 +1546,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1817,16 +1817,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3322,16 +3322,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3444,7 +3444,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3463,7 +3463,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3484,7 +3484,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc-connector.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-service-custom-vpc-connector github work
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1545,16 +1545,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1816,16 +1816,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3369,16 +3369,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3491,7 +3491,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3510,7 +3510,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3531,7 +3531,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-custom-vpc.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-service-custom-vpc github workflows YAML
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1545,16 +1545,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1816,16 +1816,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3369,16 +3369,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3491,7 +3491,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3510,7 +3510,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3531,7 +3531,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-gen2.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-service-gen2 github workflows YAML 1`] =
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-increase-timout.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-service-increase-timout github workflows
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-service-with-volumes.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-service-with-volumes github workflows YA
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1545,16 +1545,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1816,16 +1816,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3373,16 +3373,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3495,7 +3495,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3514,7 +3514,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3535,7 +3535,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-session-affinity.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-session-affinity github workflows YAML 1
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-storybook.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-storybook.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-storybook github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-dev:
@@ -565,16 +565,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-review:
@@ -850,16 +850,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1125,16 +1125,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1336,16 +1336,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1607,16 +1607,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -2844,16 +2844,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -2966,7 +2966,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -2985,7 +2985,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3006,7 +3006,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-verify.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-verify github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db-audit-dev:
@@ -912,16 +912,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db-audit-review:
@@ -1554,16 +1554,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db-app-stage:
@@ -1972,16 +1972,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db-stop-review:
@@ -2243,16 +2243,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db-app-prod:
@@ -2626,16 +2626,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db-stop-dev:
@@ -5664,16 +5664,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -5786,7 +5786,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -5805,7 +5805,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -5826,7 +5826,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-agents.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-agents github workflows YAML 1`] = 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -673,16 +673,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1069,16 +1069,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1350,16 +1350,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1561,16 +1561,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1838,16 +1838,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3329,16 +3329,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3496,7 +3496,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3515,7 +3515,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3538,7 +3538,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-gpu.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-gpu github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-ngnix.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-ngnix github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3305,16 +3305,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3427,7 +3427,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3446,7 +3446,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3467,7 +3467,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-legacy-jobs.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-sql-legacy-jobs github workflows YA
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -673,16 +673,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1069,16 +1069,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1347,16 +1347,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1579,16 +1579,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1853,16 +1853,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3642,16 +3642,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3764,7 +3764,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3783,7 +3783,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3804,7 +3804,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-multiple-dbs.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-sql-multiple-dbs github workflows Y
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db1-audit-dev:
@@ -1097,16 +1097,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db1-audit-review:
@@ -1929,16 +1929,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db1-app-stage:
@@ -2421,16 +2421,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db1-stop-review:
@@ -2795,16 +2795,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db1-app-prod:
@@ -3298,16 +3298,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     db1-stop-dev:
@@ -8054,16 +8054,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -8176,7 +8176,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -8195,7 +8195,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -8220,7 +8220,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql-reuse-db.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-sql-reuse-db github workflows YAML 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -886,16 +886,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1501,16 +1501,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1887,16 +1887,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -2190,16 +2190,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -2581,16 +2581,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -5705,16 +5705,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -5827,7 +5827,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -5846,7 +5846,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -5869,7 +5869,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-sql.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-sql github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -673,16 +673,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1069,16 +1069,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1347,16 +1347,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1582,16 +1582,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1856,16 +1856,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3738,16 +3738,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3860,7 +3860,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3879,7 +3879,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3900,7 +3900,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-with-worker.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-with-worker github workflows YAML 1`] = 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3311,16 +3311,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3433,7 +3433,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3452,7 +3452,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3473,7 +3473,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/cloud-run-worker-pool.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for cloud-run-worker-pool github workflows YAML 1`] = 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3311,16 +3311,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3433,7 +3433,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3452,7 +3452,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3473,7 +3473,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-build-job-with-tests.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for custom-build-job-with-tests github workflows YAML 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -504,16 +504,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -780,16 +780,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -980,16 +980,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1141,16 +1141,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1337,16 +1337,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -2710,16 +2710,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -2787,7 +2787,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -2806,7 +2806,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -2827,7 +2827,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/custom-build-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-build-job.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for custom-build-job github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-dev:
@@ -437,16 +437,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-review:
@@ -643,16 +643,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -840,16 +840,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1001,16 +1001,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1194,16 +1194,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -2363,16 +2363,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -2440,7 +2440,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -2459,7 +2459,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -2480,7 +2480,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-deploy.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for custom-deploy github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -671,16 +671,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1065,16 +1065,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1344,16 +1344,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1552,16 +1552,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -2773,16 +2773,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -2895,7 +2895,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -2914,7 +2914,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -2935,7 +2935,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-docker-file.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for custom-docker-file github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -662,16 +662,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1047,16 +1047,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1317,16 +1317,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1528,16 +1528,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1794,16 +1794,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3317,16 +3317,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3439,7 +3439,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3458,7 +3458,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3479,7 +3479,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-envs.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for custom-envs github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -767,16 +767,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1034,16 +1034,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -2198,16 +2198,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -2275,7 +2275,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -2294,7 +2294,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -2337,7 +2337,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/custom-verify-job.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for custom-verify-job github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -696,16 +696,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1116,16 +1116,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1420,16 +1420,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1631,16 +1631,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1931,16 +1931,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3626,16 +3626,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3748,7 +3748,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3767,7 +3767,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3788,7 +3788,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/git-submodule.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for git-submodule github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-stop-dev:
@@ -3306,16 +3306,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3428,7 +3428,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3447,7 +3447,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3468,7 +3468,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-application-customization.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for kubernetes-application-customization github workfl
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -346,16 +346,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -758,16 +758,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1190,16 +1190,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1515,16 +1515,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1800,16 +1800,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -2121,16 +2121,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -2571,16 +2571,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-rollback-dev:
@@ -4306,16 +4306,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4473,7 +4473,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4492,7 +4492,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4513,7 +4513,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-cloud-sql.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for kubernetes-with-cloud-sql github workflows YAML 1`
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -346,16 +346,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -780,16 +780,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1234,16 +1234,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1569,16 +1569,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1858,16 +1858,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -2189,16 +2189,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -2651,16 +2651,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-rollback-dev:
@@ -4406,16 +4406,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4573,7 +4573,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4592,7 +4592,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4613,7 +4613,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-jobs.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for kubernetes-with-jobs github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -346,16 +346,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -954,16 +954,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1588,16 +1588,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -2016,16 +2016,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -2385,16 +2385,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -2818,16 +2818,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3503,16 +3503,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-rollback-dev:
@@ -6780,16 +6780,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -6947,7 +6947,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -6966,7 +6966,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -6989,7 +6989,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/kubernetes-with-mongodb.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for kubernetes-with-mongodb github workflows YAML 1`] 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -346,16 +346,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -780,16 +780,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1234,16 +1234,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1569,16 +1569,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1858,16 +1858,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -2189,16 +2189,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -2651,16 +2651,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-rollback-dev:
@@ -4530,16 +4530,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4697,7 +4697,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4716,7 +4716,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4737,7 +4737,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/local-dot-env.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for local-dot-env github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -3241,16 +3241,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3363,7 +3363,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3382,7 +3382,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3403,7 +3403,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/meteor-kubernetes.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for meteor-kubernetes github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -396,16 +396,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-audit-dev:
@@ -878,16 +878,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-audit-review:
@@ -1381,16 +1381,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-app-stage:
@@ -1767,16 +1767,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-stop-review:
@@ -2104,16 +2104,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-app-prod:
@@ -2488,16 +2488,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-stop-dev:
@@ -2996,16 +2996,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     web-rollback-dev:
@@ -4812,16 +4812,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -5027,7 +5027,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -5046,7 +5046,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -5067,7 +5067,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-files.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for modify-generated-files github workflows YAML 1`] =
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -497,16 +497,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -764,16 +764,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1520,16 +1520,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -1597,7 +1597,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -1616,7 +1616,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -1643,7 +1643,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/modify-generated-yaml.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for modify-generated-yaml github workflows YAML 1`] = 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -497,16 +497,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -764,16 +764,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1520,16 +1520,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -1597,7 +1597,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -1616,7 +1616,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -1643,7 +1643,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/multiline-var.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for multiline-var github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -346,16 +346,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-audit-dev:
@@ -1168,16 +1168,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-audit-review:
@@ -2022,16 +2022,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-app-stage:
@@ -2553,16 +2553,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-stop-review:
@@ -2985,16 +2985,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-app-prod:
@@ -3527,16 +3527,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-stop-dev:
@@ -4379,16 +4379,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     kube-rollback-dev:
@@ -9479,16 +9479,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -9646,7 +9646,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -9665,7 +9665,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -9690,7 +9690,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/native-app.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for native-app github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-dev:
@@ -867,16 +867,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-review:
@@ -1462,16 +1462,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-app-stage:
@@ -1829,16 +1829,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -2048,16 +2048,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-app-prod:
@@ -2416,16 +2416,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -4725,16 +4725,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4847,7 +4847,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4866,7 +4866,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4889,7 +4889,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-custom-image.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for node-build-with-custom-image github workflows YAML
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -662,16 +662,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1047,16 +1047,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1317,16 +1317,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1528,16 +1528,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1794,16 +1794,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3285,16 +3285,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3407,7 +3407,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3426,7 +3426,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3447,7 +3447,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/node-build-with-docker-additions.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for node-build-with-docker-additions github workflows 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -667,16 +667,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1057,16 +1057,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1332,16 +1332,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1543,16 +1543,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1814,16 +1814,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3313,16 +3313,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3435,7 +3435,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3454,7 +3454,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3475,7 +3475,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/npm-package.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for npm-package github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -244,16 +244,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     lib-audit-dev:
@@ -442,7 +442,7 @@ catladder-main.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -622,16 +622,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     lib-audit-review:
@@ -988,16 +988,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     lib-app-prod:
@@ -1801,16 +1801,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -1923,7 +1923,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a3
     - semanticRelease
   after_script: &a4
@@ -1943,7 +1943,7 @@ create release:
       allow_failure: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a3
   after_script: *a4
   rules:

--- a/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/override-secrets.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for override-secrets github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     my-app-audit-dev:
@@ -673,16 +673,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     my-app-audit-review:
@@ -1075,16 +1075,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     my-app-app-stage:
@@ -1353,16 +1353,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     my-app-stop-review:
@@ -1566,16 +1566,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     my-app-app-prod:
@@ -1840,16 +1840,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     my-app-stop-dev:
@@ -3359,16 +3359,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3481,7 +3481,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3500,7 +3500,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3521,7 +3521,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/pages-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pages-deploy.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for pages-deploy github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     docs-deploy-dev:
@@ -455,16 +455,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -528,7 +528,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -547,7 +547,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -568,7 +568,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pipelines-config.test.ts.snap
@@ -54,23 +54,23 @@ exports[`matches snapshot for pipelines-config github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -126,7 +126,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -297,16 +297,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -668,16 +668,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -1058,16 +1058,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1334,16 +1334,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1545,16 +1545,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1816,16 +1816,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3307,16 +3307,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3429,7 +3429,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3448,7 +3448,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3469,7 +3469,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-cloud-run.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for pnpm-cloud-run github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-dev:
@@ -619,16 +619,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-audit-review:
@@ -961,16 +961,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-stage:
@@ -1220,16 +1220,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-review:
@@ -1431,16 +1431,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-app-prod:
@@ -1686,16 +1686,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     www-stop-dev:
@@ -3177,16 +3177,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3299,7 +3299,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3318,7 +3318,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3339,7 +3339,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/pnpm-workspace-api-www.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for pnpm-workspace-api-www github workflows YAML 1`] =
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-dev:
@@ -662,16 +662,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-review:
@@ -1049,16 +1049,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-stage:
@@ -1357,16 +1357,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1628,16 +1628,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-prod:
@@ -1940,16 +1940,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -4232,16 +4232,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4354,7 +4354,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4373,7 +4373,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4396,7 +4396,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/project-images.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/project-images.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for project-images github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     image-db-tools:
@@ -565,16 +565,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     image-db-tools:
@@ -902,16 +902,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     image-db-tools:
@@ -1204,16 +1204,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     image-db-tools:
@@ -1465,16 +1465,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     image-db-tools:
@@ -1763,16 +1763,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     image-db-tools:
@@ -3100,16 +3100,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3273,7 +3273,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3292,7 +3292,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3313,7 +3313,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker-dockerfile.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker-dockerfile.test.ts.snap
@@ -121,16 +121,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -243,7 +243,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -262,7 +262,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -283,7 +283,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/rails-k8s-with-worker.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for rails-k8s-with-worker github workflows YAML 1`] = 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-dev:
@@ -584,16 +584,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-audit-review:
@@ -890,16 +890,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-docker-stage:
@@ -1116,16 +1116,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-stop-review:
@@ -1358,16 +1358,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-docker-prod:
@@ -1580,16 +1580,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-stop-dev:
@@ -2001,16 +2001,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app-rollback-dev:
@@ -3493,16 +3493,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3615,7 +3615,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3634,7 +3634,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3655,7 +3655,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/referencing-other-vars.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for referencing-other-vars github workflows YAML 1`] =
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -346,16 +346,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-audit-dev:
@@ -1188,16 +1188,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-audit-review:
@@ -2062,16 +2062,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-app-stage:
@@ -2607,16 +2607,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-stop-review:
@@ -3014,16 +3014,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-app-prod:
@@ -3570,16 +3570,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app1-stop-dev:
@@ -4347,16 +4347,16 @@ catladder-rollback.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     app3-rollback-dev:
@@ -8844,16 +8844,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -9011,7 +9011,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -9030,7 +9030,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -9055,7 +9055,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/wait-for-other-deploy.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for wait-for-other-deploy github workflows YAML 1`] = 
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -246,16 +246,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-dev:
@@ -693,16 +693,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-audit-review:
@@ -1162,16 +1162,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-stage:
@@ -1424,16 +1424,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-app-prod:
@@ -3137,16 +3137,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -3214,7 +3214,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -3233,7 +3233,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -3254,7 +3254,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www-turbo-cache.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for workspace-api-www-turbo-cache github workflows YAM
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-dev:
@@ -725,16 +725,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-review:
@@ -1175,16 +1175,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-stage:
@@ -1514,16 +1514,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1785,16 +1785,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-prod:
@@ -2128,16 +2128,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -4428,16 +4428,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4550,7 +4550,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4569,7 +4569,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4592,7 +4592,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-api-www.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for workspace-api-www github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-dev:
@@ -722,16 +722,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-review:
@@ -1169,16 +1169,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-stage:
@@ -1505,16 +1505,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1776,16 +1776,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-prod:
@@ -2116,16 +2116,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -4408,16 +4408,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4530,7 +4530,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4549,7 +4549,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4572,7 +4572,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/workspace-verify.test.ts.snap
@@ -53,23 +53,23 @@ exports[`matches snapshot for workspace-verify github workflows YAML 1`] = `
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     create-release:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -125,7 +125,7 @@ catladder-release-on-green.yml:
       name: create release
       runs-on: ubuntu-latest
       container:
-        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
         credentials:
           username: \${{ github.actor }}
           password: \${{ github.token }}
@@ -296,16 +296,16 @@ catladder-main.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-dev:
@@ -755,16 +755,16 @@ catladder-review.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-audit-review:
@@ -1236,16 +1236,16 @@ catladder-release.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-stage:
@@ -1605,16 +1605,16 @@ catladder-review-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-review:
@@ -1876,16 +1876,16 @@ catladder-deploy.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     ws-myworkspace-app-prod:
@@ -2250,16 +2250,16 @@ catladder-stop.yml:
             docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
             collapseable_section_end "docker-login"
             collapseable_section_start "check-image" "Checking if image exists"
-            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e already exists, skipping build"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
               exit 0
             fi
             collapseable_section_end "check-image"
             collapseable_section_start "docker-build" "Building image"
-            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
             collapseable_section_end "docker-build"
             collapseable_section_start "docker-push" "Pushing image"
-            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:b0b80a328f2e
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
             collapseable_section_end "docker-push"
           shell: bash
     api-stop-dev:
@@ -4782,16 +4782,16 @@ before_script:
     - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
     - collapseable_section_end "docker-login"
     - collapseable_section_start "check-image" "Checking if image exists"
-    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e > /dev/null 2>&1; then
-    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e already exists, skipping build"'
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
     - '  exit 0'
     - fi
     - collapseable_section_end "check-image"
     - collapseable_section_start "docker-build" "Building image"
-    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
     - collapseable_section_end "docker-build"
     - collapseable_section_start "docker-push" "Pushing image"
-    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
     - collapseable_section_end "docker-push"
   rules:
     - &a1
@@ -4904,7 +4904,7 @@ before_script:
   interruptible: true
 create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script:
     - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
   rules: &a7
@@ -4923,7 +4923,7 @@ create release:
   allow_failure: true
 🚀 release once pipeline succeeds:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: &a5
     - semanticRelease
   after_script: &a6
@@ -4946,7 +4946,7 @@ create release:
       optional: true
 ⚠️ force create release:
   stage: release
-  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:b0b80a328f2e
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
   script: *a5
   after_script: *a6
   rules: *a7

--- a/runner-images/semantic-release/Dockerfile
+++ b/runner-images/semantic-release/Dockerfile
@@ -21,6 +21,7 @@ RUN yarn global add \
     @semantic-release/git@11.0.0 \
     @semantic-release/changelog@7.0.0 \
     @semantic-release/gitlab@13.3.3 \
+    @semantic-release/github@12.0.9 \
     @semantic-release/exec@7.1.0
 
 RUN mkdir -p /scripts

--- a/runner-images/semantic-release/scripts/semanticRelease
+++ b/runner-images/semantic-release/scripts/semanticRelease
@@ -40,10 +40,20 @@ fi
 echo "doing semantic release"
 
 if [ "$GITHUB_ACTIONS" = "true" ]; then
-  # the gitlab publish plugin would fail on github; skip it (the tag
-  # and changelog commit still happen, only the gitlab release entry
-  # is gitlab-specific)
-  PUBLISH_PLUGIN=""
+  # the github counterpart of the gitlab plugin below: it creates the
+  # entry on the releases page with the generated notes. Everything
+  # beyond that is switched off on purpose — commenting on the
+  # pull requests/issues of a release and labelling them would need
+  # `issues: write` / `pull-requests: write` on the release job, which
+  # only exists to release.
+  PUBLISH_PLUGIN=',
+    ["@semantic-release/github", {
+      "successComment": false,
+      "failComment": false,
+      "failTitle": false,
+      "labels": false,
+      "releasedLabels": false
+    }]'
 else
   # no gitlabUrl: the plugin derives it from the CI-provided variables
   # of the running instance. It used to be hardcoded to panter's gitlab,

--- a/skills/catladder-releases/SKILL.md
+++ b/skills/catladder-releases/SKILL.md
@@ -52,6 +52,11 @@ workflows the same way (`▶️ catladder deploy`, `⏹️ catladder stop`,
 
 ## `method` — how the version is decided
 
+Whichever method runs, the release ends the same way: a `vX.Y.Z` tag, a
+`CHANGELOG.md` entry, a `chore(release): <version>` commit, and an
+entry on the releases page of the git host (gitlab `/-/releases`,
+github `/releases`) carrying the release notes.
+
 ### `semantic-release` (default)
 The version is derived automatically from **conventional commit
 messages** since the last release (`fix:` → patch, `feat:` → minor,
@@ -63,8 +68,10 @@ Developers declare changes intentionally as **`.changeset/*.md` files**
 (the official changesets format: a bump type + a human-written summary).
 The release job consumes all pending changesets, takes the highest bump,
 computes the next version from the last `v*` git tag, writes the
-changelog, commits `chore(release): <version>`, and pushes the tag. An
-empty `.changeset/` folder means there is nothing to release.
+changelog, commits `chore(release): <version>`, pushes the tag and
+creates the release entry on the git host (gitlab `/-/releases`,
+github `/releases`) with the changelog as its description. An empty
+`.changeset/` folder means there is nothing to release.
 
 Add a changeset by creating `.changeset/<name>.md`:
 
@@ -121,6 +128,13 @@ the `security` commands in the `catladder-cli` reference.
   MR adding a changeset describing the accumulated work.
 - Wrong version bump → check commit types (semantic-release) or the bump
   levels in the changeset files (changesets).
+- Tag pushed but nothing on the releases page → with `changesets` the
+  entry is created via the host api after the push and never fails the
+  job (the release itself is done); look for the `could not create the
+  release entry` warning at the end of the release job log. On gitlab
+  it needs `GL_TOKEN` (`catladder project renew-token`). Releases
+  tagged before catladder created entries have none — that is not fixed
+  retroactively, create them by hand from the tag.
 - Inspect the job with `yarn catladder project ci job-log` (see the
   `catladder-cli` skill).
 


### PR DESCRIPTION
A release ended at the pushed tag, leaving the releases page empty — noticed on [food-2050](https://git.panter.ch/manul/wea/food-2050/-/releases) and on [this repo](https://github.com/panter/catladder/releases) itself.

## What was wrong

- **changesets, both backends**: the release job pushed the commit and the tag and stopped there. On the semantic-release path `@semantic-release/gitlab` created the release entry; the changesets path never had an equivalent.
- **semantic-release on github**: no publish plugin at all — the gitlab one is gitlab-only, and nothing took its place.

## What this does

- New `releaseEntry.ts`, called by the changesets release job right after the push: `POST /projects/:id/releases` with `GL_TOKEN` on gitlab, `POST /repos/:repo/releases` with the workflow token on github (the release job already declares `contents: write`, so no workflow change). The changelog entries become the description.
  It is deliberately **non-fatal**: when it runs, the commit and tag are pushed and the taggedRelease pipeline is on its way, so an api error warns loudly instead of turning a finished release red — a rerun would fail on the existing tag anyway.
- semantic-release on github gets `@semantic-release/github@12.0.9`, configured to create the release **only**: `successComment`, `failComment`, `failTitle`, `labels` and `releasedLabels` are off, so the job keeps its `contents: write`-only permissions instead of needing `issues: write` / `pull-requests: write` just to comment on released PRs. Projects with their own `.releaserc` are unaffected, as before.

## Notes

- The semantic-release image gains a dependency → its content hash moves → the example snapshots change. Nothing else in the generated yaml differs.
- Verified the generated `.releaserc` still parses (it is read as YAML) and carries the right plugin list on both backends.
- Releases tagged before this has no entry retroactively; the two v5.0.0 entries were created by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)