### PR TITLE
feat(env): explicit env triggers (`on`), `autoStop`, and cloud run `revisionsToKeep`

### DIFF
--- a/.changeset/env-triggers-and-autostop.md
+++ b/.changeset/env-triggers-and-autostop.md
@@ -1,0 +1,5 @@
+---
+"catladder": minor
+---
+
+Environments are now explicitly configurable instead of implied by their type, via the new project-wide top-level `environments` config: `on` controls when an env deploys (`"mainBranch"`, `"mr"`, `"taggedRelease"`, `{ branch: "next" }` for a stable branch-tracking environment with its own pipeline, or `false`) and `autoStop` the gitlab auto-stop duration (`false` to disable, per-component overridable via `env.<name>.autoStop`). Extra envs declared in `environments` apply to every component (opt out with `env.<name>: false`). Cloud run deploys additionally accept `revisionsToKeep` (the rollback history the post-deploy cleanup preserves). The env type keeps supplying the defaults — dev on mainBranch with 4 weeks autoStop, review per-MR with 1 week, stage/prod on tagged releases, prod keeping 5 revisions — so existing configs generate identical pipelines.

--- a/.claude/skills/catladder-config/SKILL.md
+++ b/.claude/skills/catladder-config/SKILL.md
@@ -35,6 +35,10 @@ const config = {
   appName: "my-app",
   customerName: "pan",
   pipelines: { gitlab: true, github: true }, // which CI systems to generate
+  environments: {              // optional: project-wide env declarations/tuning
+    review: { autoStop: "3 days" },
+    next: { type: "dev", on: { branch: "next" } }, // extra branch-tracking env
+  },
   components: {
     www: {
       dir: "frontend",          // working directory of this component
@@ -61,8 +65,24 @@ Key concepts:
 - **Environments**: `dev` (deployed on push to the main branch),
   `review` (per merge/pull request), `stage` and `prod` (deployed on
   tagged releases), `local` (only for local development via catenv).
-  Per-env overrides live under `env.<name>` and can override vars,
-  deploy settings, and more.
+  Environments are project-wide: the top-level `environments` config
+  declares and tunes them consistently for all components, while
+  per-component `env.<name>` entries only carry component-local
+  overrides (vars, deploy settings, host, autoStop) or `false` to opt
+  the component out. In `environments`:
+  - `on` — when the env deploys: `"mainBranch"`, `"mr"`,
+    `"taggedRelease"`, `{ branch: "next" }` (a stable env deploying on
+    pushes to that branch), or `false` (in no pipeline). `on: "mr"`
+    makes an env a review app (one instance per MR/PR, torn down on
+    close). Defaults from the env type.
+  - `autoStop` — how long a stoppable environment stays up after its
+    last deploy before gitlab stops it (e.g. `"3 days"`; `false`
+    disables). Defaults: review `"1 week"`, dev `"4 weeks"`, others
+    never. GitLab only — github review apps stop when their PR closes.
+    Components can override it per env (`env.<name>.autoStop`).
+  - Extra envs are declared with any name plus a `type` (which supplies
+    the defaults) — every component deploys to them unless it opts out:
+    `environments: { next: { type: "dev", on: { branch: "next" } } }`.
 - **Pipelines**: `pipelines: { gitlab: true, github: true }` selects
   which CI systems get generated files. Options objects instead of
   `true` allow per-pipeline settings (e.g. `runnerVariables`).

--- a/.claude/skills/catladder-deploys/SKILL.md
+++ b/.claude/skills/catladder-deploys/SKILL.md
@@ -73,6 +73,11 @@ Everything app-level lives under `values`:
   completion jobs, and always-on background worker pools.
 - `cloudSql` — attach an (unmanaged) CloudSQL instance; choose the
   connection-string format (`prisma` default, `rails`, `jdbc`).
+  `deleteDatabaseOnStop` controls whether the database is dropped when
+  the environment stops (default: true for review envs, false else).
+- `revisionsToKeep` — how many inactive revisions (the rollback
+  history) the post-deploy cleanup keeps; older revisions and their
+  images are deleted. Default: 5 on prod envs, 0 everywhere else.
 - `execute` — run a script/job/HTTP call at a deploy lifecycle point
   (`preDeploy`/`postDeploy`/`preStop`/`postStop`) or on a `schedule`.
   Prefer this over the deprecated `when`/`schedule` fields on `jobs`.

--- a/.claude/skills/catladder-pipelines/SKILL.md
+++ b/.claude/skills/catladder-pipelines/SKILL.md
@@ -13,11 +13,20 @@ generated YAML.
 
 ## Triggers and environments
 
-| Trigger | Runs on | Deploys to |
+| Trigger | Runs on | Deploys to (default) |
 |---|---|---|
 | `mainBranch` | push to the main branch | `dev` |
 | `mr` | merge/pull requests | `review` (one app per MR/PR) |
 | `taggedRelease` | git tags | `stage`, `prod` |
+| `{ branch: "<name>" }` | push to that branch | envs declaring it via `on` |
+
+The trigger of each env is its `on` in the top-level `environments`
+config (project-wide — components cannot diverge), defaulting from the
+env type as in the table. An env with `on: { branch: "next" }` gets its
+own pipeline (gitlab: rules on `$CI_COMMIT_BRANCH`; github: a
+`catladder-branch-<name>.yml` workflow) and deploys as one stable,
+branch-tracking environment — unlike review apps, it is not
+per-instance and is stopped via the manual stop job/workflow.
 
 Generated layout:
 

--- a/apps/cli/src/commands/project/commandPortForward.ts
+++ b/apps/cli/src/commands/project/commandPortForward.ts
@@ -59,7 +59,7 @@ export const commandPortForward = defineCommand({
 
       const { fullName } = context.environment;
       let serviceName: string = fullName.toString();
-      if (context.environment.envType === "review") {
+      if (context.environment.instance.type === "review") {
         const mr = await ctx.get("mr");
         serviceName = serviceName
           .toString()

--- a/packages/pipeline/examples/__snapshots__/env-triggers.test.ts.snap
+++ b/packages/pipeline/examples/__snapshots__/env-triggers.test.ts.snap
@@ -1,0 +1,6052 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches snapshot for env-triggers github workflows YAML 1`] = `
+"catladder-create-release.yml:
+  name: 🚀 catladder create release
+  on:
+    workflow_dispatch: {}
+  permissions:
+    contents: read
+    packages: write
+  env: &a1
+    CL_JOB_TOKEN: \${{ github.token }}
+    CL_REGISTRY: ghcr.io
+    CL_REGISTRY_IMAGE: ghcr.io/\${{ github.repository }}
+    CL_REGISTRY_USER: \${{ github.actor }}
+    CL_PR_NUMBER: \${{ github.event.number }}
+  jobs:
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    create-release:
+      name: create release
+      runs-on: ubuntu-latest
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      permissions:
+        contents: write
+        actions: write
+        packages: read
+      needs:
+        - catladder-image-semantic-release
+      env:
+        GITHUB_TOKEN: \${{ github.token }}
+        CATLADDER_RELEASE_KEY: \${{ secrets.CATLADDER_RELEASE_KEY }}
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+        - name: check main workflow
+          id: queue
+          run: node .catladder-generated/catci/index.js release github-queue-check
+          shell: bash
+        - name: create release
+          if: steps.queue.outputs.queued != 'true'
+          run: semanticRelease
+          shell: bash
+catladder-release-on-green.yml:
+  name: 🛠️ catladder release on green
+  on:
+    workflow_run:
+      workflows:
+        - 🛠️ catladder main
+      types:
+        - completed
+  env: *a1
+  jobs:
+    guard:
+      name: check queued release
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+      env:
+        GITHUB_TOKEN: \${{ github.token }}
+      outputs:
+        release: \${{ steps.guard.outputs.release }}
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: check queued release
+          id: guard
+          run: node .catladder-generated/catci/index.js release github-queued-guard "\${{ github.event.workflow_run.head_sha }}" "\${{ github.event.workflow_run.conclusion }}"
+          shell: bash
+    create-release:
+      name: create release
+      runs-on: ubuntu-latest
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      permissions:
+        contents: write
+        actions: write
+        packages: read
+      needs:
+        - guard
+      env:
+        GITHUB_TOKEN: \${{ github.token }}
+        CATLADDER_RELEASE_KEY: \${{ secrets.CATLADDER_RELEASE_KEY }}
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+        - name: create release
+          run: semanticRelease
+          shell: bash
+      if: \${{ needs.guard.outputs.release == 'true' }}
+catladder-main.yml:
+  name: 🛠️ catladder main
+  on:
+    push:
+      branches:
+        - main
+  permissions:
+    contents: read
+    packages: write
+  env: *a1
+  jobs:
+    catladder-image-jobs-default:
+      name: 🐳 catladder image jobs-default
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image jobs-default
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-docker-build:
+      name: 🐳 catladder image docker-build
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image docker-build
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    www-audit-dev:
+      name: www 🛡 audit | dev
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: dev
+      continue-on-error: true
+      env:
+        CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🛡 audit
+          id: main
+          run: bash .catladder-generated/github/scripts/www-audit-dev.sh
+          shell: bash
+    www-lint-dev:
+      name: www 👮 lint | dev
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: dev
+      env:
+        CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache/restore@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 👮 lint
+          id: main
+          run: bash .catladder-generated/github/scripts/www-lint-dev.sh
+          shell: bash
+    www-test-dev:
+      name: www 🧪 test | dev
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: dev
+      env:
+        CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache/restore@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🧪 test
+          id: main
+          run: bash .catladder-generated/github/scripts/www-test-dev.sh
+          shell: bash
+    www-app-dev:
+      name: www 🔨 app | dev
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: dev
+      env:
+        CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🔨 app
+          id: main
+          run: bash .catladder-generated/github/scripts/www-app-dev.sh
+          shell: bash
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: www-app-dev
+            path: |-
+              www/__build_info.json
+              www/.next
+              www/dist
+            if-no-files-found: warn
+            include-hidden-files: true
+    www-docker-dev:
+      name: www 🔨 docker | dev
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - www-app-dev
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: dev
+      env:
+        DOCKER_BUILDKIT: '1'
+        CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-yarn
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: Download artifacts from www-app-dev
+          uses: actions/download-artifact@v4
+          with:
+            name: www-app-dev
+        - name: 🔨 docker
+          id: main
+          run: bash .catladder-generated/github/scripts/www-docker-dev.sh
+          shell: bash
+    www-deploy-dev:
+      name: www 🚀 Deploy | dev
+      runs-on: ubuntu-latest
+      needs:
+        - www-app-dev
+        - www-audit-dev
+        - www-docker-dev
+        - www-lint-dev
+        - www-test-dev
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: dev-www
+        url: \${{ steps.main.outputs.url }}
+      env:
+        CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🚀 Deploy
+          id: main
+          run: bash .catladder-generated/github/scripts/www-deploy-dev.sh
+          shell: bash
+catladder-review.yml:
+  name: 🛠️ catladder review
+  on:
+    pull_request:
+      types:
+        - opened
+        - synchronize
+        - reopened
+  concurrency:
+    group: catladder-review-\${{ github.event.number }}
+    cancel-in-progress: true
+  permissions:
+    contents: read
+    packages: write
+  env: *a1
+  jobs:
+    catladder-image-jobs-default:
+      name: 🐳 catladder image jobs-default
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image jobs-default
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-docker-build:
+      name: 🐳 catladder image docker-build
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image docker-build
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    www-audit-review:
+      name: www 🛡 audit | review
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: review
+      continue-on-error: true
+      env:
+        CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🛡 audit
+          id: main
+          run: bash .catladder-generated/github/scripts/www-audit-review.sh
+          shell: bash
+    www-lint-review:
+      name: www 👮 lint | review
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: review
+      env:
+        CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache/restore@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 👮 lint
+          id: main
+          run: bash .catladder-generated/github/scripts/www-lint-review.sh
+          shell: bash
+    www-test-review:
+      name: www 🧪 test | review
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: review
+      env:
+        CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache/restore@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🧪 test
+          id: main
+          run: bash .catladder-generated/github/scripts/www-test-review.sh
+          shell: bash
+    www-app-review:
+      name: www 🔨 app | review
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: review
+      env:
+        CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🔨 app
+          id: main
+          run: bash .catladder-generated/github/scripts/www-app-review.sh
+          shell: bash
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: www-app-review
+            path: |-
+              www/__build_info.json
+              www/.next
+              www/dist
+            if-no-files-found: warn
+            include-hidden-files: true
+    www-docker-review:
+      name: www 🔨 docker | review
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - www-app-review
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: review
+      env:
+        DOCKER_BUILDKIT: '1'
+        CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-yarn
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: Download artifacts from www-app-review
+          uses: actions/download-artifact@v4
+          with:
+            name: www-app-review
+        - name: 🔨 docker
+          id: main
+          run: bash .catladder-generated/github/scripts/www-docker-review.sh
+          shell: bash
+    www-deploy-review:
+      name: www 🚀 Deploy | review
+      runs-on: ubuntu-latest
+      needs:
+        - www-app-review
+        - www-audit-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: review-www
+        url: \${{ steps.main.outputs.url }}
+      env:
+        CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🚀 Deploy
+          id: main
+          run: bash .catladder-generated/github/scripts/www-deploy-review.sh
+          shell: bash
+    catladder-ok:
+      name: catladder ✅
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - catladder-image-jobs-default
+        - catladder-image-semantic-release
+        - www-app-review
+        - www-audit-review
+        - www-deploy-review
+        - www-docker-review
+        - www-lint-review
+        - www-test-review
+      if: always()
+      steps:
+        - name: catladder ✅
+          run: |-
+            results='\${{ toJSON(needs) }}'
+            echo "$results"
+            if echo "$results" | grep -qE '"result": "(failure|cancelled|skipped)"'; then
+              echo "a required job did not succeed"; exit 1
+            fi
+          shell: bash
+catladder-release.yml:
+  name: 🛠️ catladder release
+  on:
+    push:
+      tags:
+        - v*
+    workflow_dispatch: {}
+  permissions:
+    contents: read
+    packages: write
+  env: *a1
+  jobs:
+    catladder-image-jobs-default:
+      name: 🐳 catladder image jobs-default
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image jobs-default
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-docker-build:
+      name: 🐳 catladder image docker-build
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image docker-build
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    www-app-stage:
+      name: www 🔨 app | stage
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: stage
+      env:
+        CL_stage_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_stage_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🔨 app
+          id: main
+          run: bash .catladder-generated/github/scripts/www-app-stage.sh
+          shell: bash
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: www-app-stage
+            path: |-
+              www/__build_info.json
+              www/.next
+              www/dist
+            if-no-files-found: warn
+            include-hidden-files: true
+    www-docker-stage:
+      name: www 🔨 docker | stage
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - www-app-stage
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: stage
+      env:
+        DOCKER_BUILDKIT: '1'
+        CL_stage_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_stage_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-yarn
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: Download artifacts from www-app-stage
+          uses: actions/download-artifact@v4
+          with:
+            name: www-app-stage
+        - name: 🔨 docker
+          id: main
+          run: bash .catladder-generated/github/scripts/www-docker-stage.sh
+          shell: bash
+    www-deploy-stage:
+      name: www 🚀 Deploy | stage
+      runs-on: ubuntu-latest
+      needs:
+        - www-app-stage
+        - www-docker-stage
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: stage-www
+        url: \${{ steps.main.outputs.url }}
+      env:
+        CL_stage_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_stage_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🚀 Deploy
+          id: main
+          run: bash .catladder-generated/github/scripts/www-deploy-stage.sh
+          shell: bash
+catladder-branch-next.yml:
+  name: 🛠️ catladder next
+  on:
+    push:
+      branches:
+        - next
+  permissions:
+    contents: read
+    packages: write
+  env: *a1
+  jobs:
+    catladder-image-jobs-default:
+      name: 🐳 catladder image jobs-default
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image jobs-default
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-docker-build:
+      name: 🐳 catladder image docker-build
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image docker-build
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    www-audit-next:
+      name: www 🛡 audit | next
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: next
+      continue-on-error: true
+      env:
+        CL_next_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_next_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🛡 audit
+          id: main
+          run: bash .catladder-generated/github/scripts/www-audit-next.sh
+          shell: bash
+    www-lint-next:
+      name: www 👮 lint | next
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: next
+      env:
+        CL_next_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_next_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache/restore@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 👮 lint
+          id: main
+          run: bash .catladder-generated/github/scripts/www-lint-next.sh
+          shell: bash
+    www-test-next:
+      name: www 🧪 test | next
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: next
+      env:
+        CL_next_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_next_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache/restore@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🧪 test
+          id: main
+          run: bash .catladder-generated/github/scripts/www-test-next.sh
+          shell: bash
+    www-app-next:
+      name: www 🔨 app | next
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: next
+      env:
+        CL_next_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_next_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🔨 app
+          id: main
+          run: bash .catladder-generated/github/scripts/www-app-next.sh
+          shell: bash
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: www-app-next
+            path: |-
+              www/__build_info.json
+              www/.next
+              www/dist
+            if-no-files-found: warn
+            include-hidden-files: true
+    www-docker-next:
+      name: www 🔨 docker | next
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - www-app-next
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: next
+      env:
+        DOCKER_BUILDKIT: '1'
+        CL_next_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_next_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-yarn
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: Download artifacts from www-app-next
+          uses: actions/download-artifact@v4
+          with:
+            name: www-app-next
+        - name: 🔨 docker
+          id: main
+          run: bash .catladder-generated/github/scripts/www-docker-next.sh
+          shell: bash
+    www-deploy-next:
+      name: www 🚀 Deploy | next
+      runs-on: ubuntu-latest
+      needs:
+        - www-app-next
+        - www-audit-next
+        - www-docker-next
+        - www-lint-next
+        - www-test-next
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: next-www
+        url: \${{ steps.main.outputs.url }}
+      env:
+        CL_next_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_next_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🚀 Deploy
+          id: main
+          run: bash .catladder-generated/github/scripts/www-deploy-next.sh
+          shell: bash
+catladder-review-stop.yml:
+  name: 🛑 catladder stop review app
+  on:
+    pull_request:
+      types:
+        - closed
+    workflow_dispatch:
+      inputs:
+        pr:
+          description: number of the pull request whose review app to stop
+          required: true
+          type: string
+  permissions:
+    contents: read
+    packages: write
+  env:
+    CL_JOB_TOKEN: \${{ github.token }}
+    CL_REGISTRY: ghcr.io
+    CL_REGISTRY_IMAGE: ghcr.io/\${{ github.repository }}
+    CL_REGISTRY_USER: \${{ github.actor }}
+    CL_PR_NUMBER: \${{ github.event.number || inputs.pr }}
+  jobs:
+    catladder-image-jobs-default:
+      name: 🐳 catladder image jobs-default
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image jobs-default
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-docker-build:
+      name: 🐳 catladder image docker-build
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image docker-build
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    www-stop-review:
+      name: www 🛑 Stop ⚠️ | review
+      runs-on: ubuntu-latest
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: review-www
+      env:
+        CL_review_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_review_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: 🛑 Stop ⚠️
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "injectvars" "Injecting variables"
+            export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+            collapseable_section_end "injectvars"
+            set +e
+            gcloud auth activate-service-account --key-file=<(echo "$CL_review_www_GCLOUD_DEPLOY_credentialsKey")
+            gcloud run services delete $(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}') --project=google-project-id --region=europe-west6
+            gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown") --quiet --delete-tags
+            gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+            set +e
+            gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www --quiet --delete-tags
+            set -e
+            set -e
+          shell: bash
+catladder-deploy.yml:
+  name: ▶️ catladder deploy prod
+  on:
+    workflow_dispatch: {}
+  permissions:
+    contents: read
+    packages: write
+  env: *a1
+  jobs:
+    catladder-image-jobs-default:
+      name: 🐳 catladder image jobs-default
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image jobs-default
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-docker-build:
+      name: 🐳 catladder image docker-build
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image docker-build
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    www-app-prod:
+      name: www 🔨 app | prod
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-jobs-default
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: prod
+      env:
+        CL_prod_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_prod_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-node-modules
+          id: cache-node-modules
+          uses: actions/cache@v4
+          with:
+            path: |-
+              www/node_modules
+              www/.yarn/install-state.gz
+            key: www-node-modules-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-node-modules-
+        - name: Cache www-yarn
+          if: \${{ steps.cache-node-modules.outputs.cache-hit != 'true' }}
+          uses: actions/cache@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: 🔨 app
+          id: main
+          run: bash .catladder-generated/github/scripts/www-app-prod.sh
+          shell: bash
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v4
+          with:
+            name: www-app-prod
+            path: |-
+              www/__build_info.json
+              www/.next
+              www/dist
+            if-no-files-found: warn
+            include-hidden-files: true
+    www-docker-prod:
+      name: www 🔨 docker | prod
+      runs-on: ubuntu-latest
+      needs:
+        - catladder-image-docker-build
+        - www-app-prod
+      container:
+        image: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+        credentials:
+          username: \${{ github.actor }}
+          password: \${{ github.token }}
+      environment:
+        name: prod
+      env:
+        DOCKER_BUILDKIT: '1'
+        CL_prod_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_prod_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: Cache www-yarn
+          uses: actions/cache/restore@v4
+          with:
+            path: www/.yarn
+            key: www-yarn-\${{ hashFiles('www/yarn.lock') }}
+            restore-keys: www-yarn-
+        - name: Download artifacts from www-app-prod
+          uses: actions/download-artifact@v4
+          with:
+            name: www-app-prod
+        - name: 🔨 docker
+          id: main
+          run: bash .catladder-generated/github/scripts/www-docker-prod.sh
+          shell: bash
+    www-deploy-prod:
+      name: www 🚀 Deploy | prod
+      runs-on: ubuntu-latest
+      needs:
+        - www-app-prod
+        - www-docker-prod
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: prod-www
+        url: \${{ steps.main.outputs.url }}
+      env:
+        CL_prod_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_prod_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🚀 Deploy
+          id: main
+          run: bash .catladder-generated/github/scripts/www-deploy-prod.sh
+          shell: bash
+catladder-stop.yml:
+  name: 🛑 catladder stop
+  on:
+    workflow_dispatch:
+      inputs:
+        job:
+          description: the task to run
+          required: true
+          type: choice
+          options:
+            - www-stop-dev
+            - www-stop-stage
+            - www-stop-prod
+            - www-stop-next
+  permissions:
+    contents: read
+    packages: write
+  env: *a1
+  jobs:
+    catladder-image-jobs-default:
+      name: 🐳 catladder image jobs-default
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image jobs-default
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/jobs-default:8c93778931df
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-docker-build:
+      name: 🐳 catladder image docker-build
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image docker-build
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/docker-build:b343b099980e
+            collapseable_section_end "docker-push"
+          shell: bash
+    catladder-image-semantic-release:
+      name: 🐳 catladder image semantic-release
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+        - name: 🐳 catladder image semantic-release
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "docker-login" "Docker Login"
+            docker login --username $CL_REGISTRY_USER --password $CL_JOB_TOKEN $CL_REGISTRY
+            collapseable_section_end "docker-login"
+            collapseable_section_start "check-image" "Checking if image exists"
+            if docker manifest inspect ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+              echo "Image ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"
+              exit 0
+            fi
+            collapseable_section_end "check-image"
+            collapseable_section_start "docker-build" "Building image"
+            DOCKER_BUILDKIT=1 docker build -t ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+            collapseable_section_end "docker-build"
+            collapseable_section_start "docker-push" "Pushing image"
+            docker push ghcr.io/\${{ github.repository }}/catladder/semantic-release:21a7a48f5d1e
+            collapseable_section_end "docker-push"
+          shell: bash
+    www-stop-dev:
+      name: www 🛑 Stop ⚠️ | dev
+      runs-on: ubuntu-latest
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: dev-www
+      env:
+        CL_dev_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_dev_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: 🛑 Stop ⚠️
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "injectvars" "Injecting variables"
+            export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+            collapseable_section_end "injectvars"
+            set +e
+            gcloud auth activate-service-account --key-file=<(echo "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey")
+            gcloud run services delete pan-test-app-dev-www --project=google-project-id --region=europe-west6
+            gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www --quiet --delete-tags
+            gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+            set -e
+          shell: bash
+      if: \${{ inputs.job == 'www-stop-dev' }}
+    www-stop-stage:
+      name: www 🛑 Stop ⚠️ | stage
+      runs-on: ubuntu-latest
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: stage-www
+      env:
+        CL_stage_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_stage_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: 🛑 Stop ⚠️
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "injectvars" "Injecting variables"
+            export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+            collapseable_section_end "injectvars"
+            set +e
+            gcloud auth activate-service-account --key-file=<(echo "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey")
+            gcloud run services delete pan-test-app-stage-www --project=google-project-id --region=europe-west6
+            gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www --quiet --delete-tags
+            gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+            set -e
+          shell: bash
+      if: \${{ inputs.job == 'www-stop-stage' }}
+    www-stop-prod:
+      name: www 🛑 Stop ⚠️ | prod
+      runs-on: ubuntu-latest
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: prod-www
+      env:
+        CL_prod_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_prod_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: 🛑 Stop ⚠️
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "injectvars" "Injecting variables"
+            export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+            collapseable_section_end "injectvars"
+            set +e
+            gcloud auth activate-service-account --key-file=<(echo "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey")
+            gcloud run services delete pan-test-app-prod-www --project=google-project-id --region=europe-west6
+            gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www --quiet --delete-tags
+            gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+            set -e
+          shell: bash
+      if: \${{ inputs.job == 'www-stop-prod' }}
+    www-stop-next:
+      name: www 🛑 Stop ⚠️ | next
+      runs-on: ubuntu-latest
+      container:
+        image: google/cloud-sdk:525.0.0
+      environment:
+        name: next-www
+      env:
+        CL_next_www_GCLOUD_DEPLOY_credentialsKey: \${{ secrets.CL_next_www_GCLOUD_DEPLOY_credentialsKey }}
+        CL_JOB_IMAGE: google/cloud-sdk:525.0.0
+      steps:
+        - name: 🛑 Stop ⚠️
+          id: main
+          run: |-
+            function escapeForDotEnv () {
+            input="\${1:-$(cat)}"
+             input="\${input//$'\\n'/\\\\n}"
+              if [[ "$input" == *\\\\n* ]]; then
+                if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+                  printf "\\"%s\\"\\n" "$input" 
+                elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+                  printf "\`%s\`\\n" "$input"
+                elif [[ "$input" == *\\"* ]]; then
+                  printf "'%s'\\n" "$input"
+                else
+                  printf "\\"%s\\"\\n" "$input"
+                fi
+              else
+                printf "%s\\n" "$input"
+              fi
+            }
+            function collapseable_section_start () {
+            local section_title="\${1}"
+              local section_description="\${2:-$section_title}"
+              echo "::group::\${section_description}"
+            }
+            function collapseable_section_end () {
+            echo "::endgroup::"
+            }
+            collapseable_section_start "injectvars" "Injecting variables"
+            export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+            collapseable_section_end "injectvars"
+            set +e
+            gcloud auth activate-service-account --key-file=<(echo "$CL_next_www_GCLOUD_DEPLOY_credentialsKey")
+            gcloud run services delete pan-test-app-next-www --project=google-project-id --region=europe-west6
+            gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www --quiet --delete-tags
+            gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+            set -e
+          shell: bash
+      if: \${{ inputs.job == 'www-stop-next' }}
+
+# ===== .catladder-generated/github/scripts/www-audit-dev.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+cd www
+yarn npm audit --environment production --severity critical --all --recursive
+
+# ===== .catladder-generated/github/scripts/www-lint-dev.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn lint
+
+# ===== .catladder-generated/github/scripts/www-test-dev.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn test
+
+# ===== .catladder-generated/github/scripts/www-app-dev.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="dev"
+export APP_DIR="www"
+export ENV_TYPE="dev"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-dev-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_dev_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+collapseable_section_end "injectvars"
+collapseable_section_start "write-dotenv-www" "write dot env for www"
+cat <<EOF > www/.env
+ENV_SHORT=dev
+APP_DIR=www
+ENV_TYPE=dev
+HOSTNAME=pan-test-app-dev-www-123456789012.europe-west6.run.app
+ROOT_URL=https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL=pan-test-app-dev-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL=https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-dev-www
+DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+DEPLOY_CLOUD_RUN_REGION=europe-west6
+GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+_ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+EOF
+collapseable_section_end "write-dotenv-www"
+echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"unknown-build-time"}' > www/__build_info.json
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn build
+
+# ===== .catladder-generated/github/scripts/www-docker-dev.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_DIR="www"
+export DOCKER_BUILD_CONTEXT="."
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+COPY --chown=node:node $APP_DIR .
+RUN yarn plugin import workspace-tools
+RUN yarn workspaces focus --production
+RUN yarn rebuild"
+export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+COPY --chown=node:node .yarn /app/.yarn"
+collapseable_section_end "injectvars"
+ensureNodeDockerfile
+collapseable_section_start "docker-login" "Docker Login"
+gcloud auth activate-service-account --key-file=<(echo "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey")
+gcloud auth configure-docker europe-west6-docker.pkg.dev
+collapseable_section_end "docker-login"
+collapseable_section_start "docker-build" "Docker build"
+docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+collapseable_section_end "docker-build"
+collapseable_section_start "docker-push" "Docker push and tag"
+docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+docker push $DOCKER_CACHE_IMAGE
+collapseable_section_end "docker-push"
+
+# ===== .catladder-generated/github/scripts/www-deploy-dev.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="dev"
+export APP_DIR="www"
+export ENV_TYPE="dev"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-dev-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_dev_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+collapseable_section_end "injectvars"
+collapseable_section_start "prepare" "Prepare..."
+gcloud auth activate-service-account --key-file=<(echo "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey")
+collapseable_section_end "prepare"
+collapseable_section_start "writeenvvars" "Write env vars to file"
+cat > ____envvars.yaml <<EOF
+ENV_SHORT: |-
+  dev
+APP_DIR: |-
+  www
+ENV_TYPE: |-
+  dev
+BUILD_INFO_BUILD_ID: |-
+  $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+BUILD_INFO_BUILD_TIME: |-
+  unknown-build-time
+BUILD_INFO_CURRENT_VERSION: |-
+  $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+HOSTNAME: |-
+  pan-test-app-dev-www-123456789012.europe-west6.run.app
+ROOT_URL: |-
+  https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL: |-
+  pan-test-app-dev-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL: |-
+  https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+  pan-test-app-dev-www
+DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+  google-project-id
+DEPLOY_CLOUD_RUN_REGION: |-
+  europe-west6
+_ALL_ENV_VAR_KEYS: |-
+  ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+EOF
+
+collapseable_section_end "writeenvvars"
+collapseable_section_start "deploy" "Deploy to cloud run"
+gcloud run deploy pan-test-app-dev-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=dev,env-name=dev,build-type=node,cloud-run-service-name=pan-test-app-dev-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+collapseable_section_end "deploy"
+collapseable_section_start "cleanup" "Cleanup"
+set +e
+gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-dev-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www@$version --quiet --delete-tags; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+set -e
+collapseable_section_end "cleanup"
+echo "url=$ROOT_URL" >> "$GITHUB_OUTPUT"
+
+# ===== .catladder-generated/github/scripts/www-audit-review.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+cd www
+yarn npm audit --environment production --severity critical --all --recursive
+
+# ===== .catladder-generated/github/scripts/www-lint-review.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn lint
+
+# ===== .catladder-generated/github/scripts/www-test-review.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn test
+
+# ===== .catladder-generated/github/scripts/www-app-review.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="review"
+export APP_DIR="www"
+export ENV_TYPE="review"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export ROOT_URL="https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export HOSTNAME_INTERNAL="$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export ROOT_URL_INTERNAL="https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}')"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_review_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+collapseable_section_end "injectvars"
+collapseable_section_start "write-dotenv-www" "write dot env for www"
+cat <<EOF > www/.env
+ENV_SHORT=review
+APP_DIR=www
+ENV_TYPE=review
+HOSTNAME=$(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+ROOT_URL=$(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+HOSTNAME_INTERNAL=$(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+ROOT_URL_INTERNAL=$(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+DEPLOY_CLOUD_RUN_SERVICE_NAME=$(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}')" | escapeForDotEnv)
+DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+DEPLOY_CLOUD_RUN_REGION=europe-west6
+GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_review_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+_ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+EOF
+collapseable_section_end "write-dotenv-www"
+echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"unknown-build-time"}' > www/__build_info.json
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn build
+
+# ===== .catladder-generated/github/scripts/www-docker-review.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_DIR="www"
+export DOCKER_BUILD_CONTEXT="."
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+COPY --chown=node:node $APP_DIR .
+RUN yarn plugin import workspace-tools
+RUN yarn workspaces focus --production
+RUN yarn rebuild"
+export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+COPY --chown=node:node .yarn /app/.yarn"
+collapseable_section_end "injectvars"
+ensureNodeDockerfile
+collapseable_section_start "docker-login" "Docker Login"
+gcloud auth activate-service-account --key-file=<(echo "$CL_review_www_GCLOUD_DEPLOY_credentialsKey")
+gcloud auth configure-docker europe-west6-docker.pkg.dev
+collapseable_section_end "docker-login"
+collapseable_section_start "docker-build" "Docker build"
+docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+collapseable_section_end "docker-build"
+collapseable_section_start "docker-push" "Docker push and tag"
+docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+docker push $DOCKER_CACHE_IMAGE
+collapseable_section_end "docker-push"
+
+# ===== .catladder-generated/github/scripts/www-deploy-review.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="review"
+export APP_DIR="www"
+export ENV_TYPE="review"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export ROOT_URL="https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export HOSTNAME_INTERNAL="$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export ROOT_URL_INTERNAL="https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}')"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_review_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+collapseable_section_end "injectvars"
+collapseable_section_start "prepare" "Prepare..."
+gcloud auth activate-service-account --key-file=<(echo "$CL_review_www_GCLOUD_DEPLOY_credentialsKey")
+collapseable_section_end "prepare"
+collapseable_section_start "writeenvvars" "Write env vars to file"
+cat > ____envvars.yaml <<EOF
+ENV_SHORT: |-
+  review
+APP_DIR: |-
+  www
+ENV_TYPE: |-
+  review
+BUILD_INFO_BUILD_ID: |-
+  $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+BUILD_INFO_BUILD_TIME: |-
+  unknown-build-time
+BUILD_INFO_CURRENT_VERSION: |-
+  $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+HOSTNAME: |-
+  $(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+ROOT_URL: |-
+  $(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+HOSTNAME_INTERNAL: |-
+  $(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+ROOT_URL_INTERNAL: |-
+  $(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+  $(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+  google-project-id
+DEPLOY_CLOUD_RUN_REGION: |-
+  europe-west6
+_ALL_ENV_VAR_KEYS: |-
+  ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+EOF
+
+collapseable_section_end "writeenvvars"
+collapseable_section_start "deploy" "Deploy to cloud run"
+gcloud run deploy $(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}') --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown"):$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=review,env-name=review,build-type=node,cloud-run-service-name=$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}') --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+collapseable_section_end "deploy"
+collapseable_section_start "cleanup" "Cleanup"
+set +e
+gcloud run revisions list --project=google-project-id --region=europe-west6 --service=$(printf %s "pan-test-app-review-$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")-www" | awk '{print tolower($0)}') --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown") --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CL_PR_NUMBER" ] && echo "pr$CL_PR_NUMBER" || echo "unknown")@$version --quiet --delete-tags; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+set +e
+gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www --quiet --delete-tags
+set -e
+set -e
+collapseable_section_end "cleanup"
+echo "url=$ROOT_URL" >> "$GITHUB_OUTPUT"
+
+# ===== .catladder-generated/github/scripts/www-app-stage.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="stage"
+export APP_DIR="www"
+export ENV_TYPE="stage"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-stage-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_stage_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+collapseable_section_end "injectvars"
+collapseable_section_start "write-dotenv-www" "write dot env for www"
+cat <<EOF > www/.env
+ENV_SHORT=stage
+APP_DIR=www
+ENV_TYPE=stage
+HOSTNAME=pan-test-app-stage-www-123456789012.europe-west6.run.app
+ROOT_URL=https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL=pan-test-app-stage-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL=https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-stage-www
+DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+DEPLOY_CLOUD_RUN_REGION=europe-west6
+GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+_ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+EOF
+collapseable_section_end "write-dotenv-www"
+echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"unknown-build-time"}' > www/__build_info.json
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn build
+
+# ===== .catladder-generated/github/scripts/www-docker-stage.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_DIR="www"
+export DOCKER_BUILD_CONTEXT="."
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+COPY --chown=node:node $APP_DIR .
+RUN yarn plugin import workspace-tools
+RUN yarn workspaces focus --production
+RUN yarn rebuild"
+export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+COPY --chown=node:node .yarn /app/.yarn"
+collapseable_section_end "injectvars"
+ensureNodeDockerfile
+collapseable_section_start "docker-login" "Docker Login"
+gcloud auth activate-service-account --key-file=<(echo "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey")
+gcloud auth configure-docker europe-west6-docker.pkg.dev
+collapseable_section_end "docker-login"
+collapseable_section_start "docker-build" "Docker build"
+docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+collapseable_section_end "docker-build"
+collapseable_section_start "docker-push" "Docker push and tag"
+docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+docker push $DOCKER_CACHE_IMAGE
+collapseable_section_end "docker-push"
+
+# ===== .catladder-generated/github/scripts/www-deploy-stage.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="stage"
+export APP_DIR="www"
+export ENV_TYPE="stage"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-stage-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_stage_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+collapseable_section_end "injectvars"
+collapseable_section_start "prepare" "Prepare..."
+gcloud auth activate-service-account --key-file=<(echo "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey")
+collapseable_section_end "prepare"
+collapseable_section_start "writeenvvars" "Write env vars to file"
+cat > ____envvars.yaml <<EOF
+ENV_SHORT: |-
+  stage
+APP_DIR: |-
+  www
+ENV_TYPE: |-
+  stage
+BUILD_INFO_BUILD_ID: |-
+  $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+BUILD_INFO_BUILD_TIME: |-
+  unknown-build-time
+BUILD_INFO_CURRENT_VERSION: |-
+  $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+HOSTNAME: |-
+  pan-test-app-stage-www-123456789012.europe-west6.run.app
+ROOT_URL: |-
+  https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL: |-
+  pan-test-app-stage-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL: |-
+  https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+  pan-test-app-stage-www
+DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+  google-project-id
+DEPLOY_CLOUD_RUN_REGION: |-
+  europe-west6
+_ALL_ENV_VAR_KEYS: |-
+  ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+EOF
+
+collapseable_section_end "writeenvvars"
+collapseable_section_start "deploy" "Deploy to cloud run"
+gcloud run deploy pan-test-app-stage-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=stage,env-name=stage,build-type=node,cloud-run-service-name=pan-test-app-stage-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+collapseable_section_end "deploy"
+collapseable_section_start "cleanup" "Cleanup"
+set +e
+gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-stage-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www@$version --quiet --delete-tags; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+set -e
+collapseable_section_end "cleanup"
+echo "url=$ROOT_URL" >> "$GITHUB_OUTPUT"
+
+# ===== .catladder-generated/github/scripts/www-app-prod.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="prod"
+export APP_DIR="www"
+export ENV_TYPE="prod"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-prod-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_prod_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+collapseable_section_end "injectvars"
+collapseable_section_start "write-dotenv-www" "write dot env for www"
+cat <<EOF > www/.env
+ENV_SHORT=prod
+APP_DIR=www
+ENV_TYPE=prod
+HOSTNAME=pan-test-app-prod-www-123456789012.europe-west6.run.app
+ROOT_URL=https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL=pan-test-app-prod-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL=https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-prod-www
+DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+DEPLOY_CLOUD_RUN_REGION=europe-west6
+GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+_ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+EOF
+collapseable_section_end "write-dotenv-www"
+echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"unknown-build-time"}' > www/__build_info.json
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn build
+
+# ===== .catladder-generated/github/scripts/www-docker-prod.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_DIR="www"
+export DOCKER_BUILD_CONTEXT="."
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+COPY --chown=node:node $APP_DIR .
+RUN yarn plugin import workspace-tools
+RUN yarn workspaces focus --production
+RUN yarn rebuild"
+export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+COPY --chown=node:node .yarn /app/.yarn"
+collapseable_section_end "injectvars"
+ensureNodeDockerfile
+collapseable_section_start "docker-login" "Docker Login"
+gcloud auth activate-service-account --key-file=<(echo "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey")
+gcloud auth configure-docker europe-west6-docker.pkg.dev
+collapseable_section_end "docker-login"
+collapseable_section_start "docker-build" "Docker build"
+docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+collapseable_section_end "docker-build"
+collapseable_section_start "docker-push" "Docker push and tag"
+docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+docker push $DOCKER_CACHE_IMAGE
+collapseable_section_end "docker-push"
+
+# ===== .catladder-generated/github/scripts/www-deploy-prod.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="prod"
+export APP_DIR="www"
+export ENV_TYPE="prod"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-prod-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_prod_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+collapseable_section_end "injectvars"
+collapseable_section_start "prepare" "Prepare..."
+gcloud auth activate-service-account --key-file=<(echo "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey")
+collapseable_section_end "prepare"
+collapseable_section_start "writeenvvars" "Write env vars to file"
+cat > ____envvars.yaml <<EOF
+ENV_SHORT: |-
+  prod
+APP_DIR: |-
+  www
+ENV_TYPE: |-
+  prod
+BUILD_INFO_BUILD_ID: |-
+  $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+BUILD_INFO_BUILD_TIME: |-
+  unknown-build-time
+BUILD_INFO_CURRENT_VERSION: |-
+  $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+HOSTNAME: |-
+  pan-test-app-prod-www-123456789012.europe-west6.run.app
+ROOT_URL: |-
+  https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL: |-
+  pan-test-app-prod-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL: |-
+  https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+  pan-test-app-prod-www
+DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+  google-project-id
+DEPLOY_CLOUD_RUN_REGION: |-
+  europe-west6
+_ALL_ENV_VAR_KEYS: |-
+  ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+EOF
+
+collapseable_section_end "writeenvvars"
+collapseable_section_start "deploy" "Deploy to cloud run"
+gcloud run deploy pan-test-app-prod-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=prod,env-name=prod,build-type=node,cloud-run-service-name=pan-test-app-prod-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+collapseable_section_end "deploy"
+collapseable_section_start "cleanup" "Cleanup"
+set +e
+gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-prod-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | tail -n +3 | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +4 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www@$version --quiet --delete-tags; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+set -e
+collapseable_section_end "cleanup"
+echo "url=$ROOT_URL" >> "$GITHUB_OUTPUT"
+
+# ===== .catladder-generated/github/scripts/www-audit-next.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+cd www
+yarn npm audit --environment production --severity critical --all --recursive
+
+# ===== .catladder-generated/github/scripts/www-lint-next.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn lint
+
+# ===== .catladder-generated/github/scripts/www-test-next.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_PATH="www"
+collapseable_section_end "injectvars"
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn test
+
+# ===== .catladder-generated/github/scripts/www-app-next.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="next"
+export APP_DIR="www"
+export ENV_TYPE="dev"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-next-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-next-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-next-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_next_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+collapseable_section_end "injectvars"
+collapseable_section_start "write-dotenv-www" "write dot env for www"
+cat <<EOF > www/.env
+ENV_SHORT=next
+APP_DIR=www
+ENV_TYPE=dev
+HOSTNAME=pan-test-app-next-www-123456789012.europe-west6.run.app
+ROOT_URL=https://pan-test-app-next-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL=pan-test-app-next-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL=https://pan-test-app-next-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-next-www
+DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+DEPLOY_CLOUD_RUN_REGION=europe-west6
+GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_next_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+_ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+EOF
+collapseable_section_end "write-dotenv-www"
+echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"unknown-build-time"}' > www/__build_info.json
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+cd www
+collapseable_section_start "nodeinstall" "Ensure node version"
+if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+collapseable_section_end "nodeinstall"
+collapseable_section_start "yarninstall" "Yarn install"
+yarn install --immutable --inline-builds
+collapseable_section_end "yarninstall"
+yarn build
+
+# ===== .catladder-generated/github/scripts/www-docker-next.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export APP_DIR="www"
+export DOCKER_BUILD_CONTEXT="."
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+COPY --chown=node:node $APP_DIR .
+RUN yarn plugin import workspace-tools
+RUN yarn workspaces focus --production
+RUN yarn rebuild"
+export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+COPY --chown=node:node .yarn /app/.yarn"
+collapseable_section_end "injectvars"
+ensureNodeDockerfile
+collapseable_section_start "docker-login" "Docker Login"
+gcloud auth activate-service-account --key-file=<(echo "$CL_next_www_GCLOUD_DEPLOY_credentialsKey")
+gcloud auth configure-docker europe-west6-docker.pkg.dev
+collapseable_section_end "docker-login"
+collapseable_section_start "docker-build" "Docker build"
+docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+collapseable_section_end "docker-build"
+collapseable_section_start "docker-push" "Docker push and tag"
+docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+docker push $DOCKER_CACHE_IMAGE
+collapseable_section_end "docker-push"
+
+# ===== .catladder-generated/github/scripts/www-deploy-next.sh =====
+#!/usr/bin/env bash
+set -eo pipefail
+
+function escapeForDotEnv () {
+input="\${1:-$(cat)}"
+ input="\${input//$'\\n'/\\\\n}"
+  if [[ "$input" == *\\\\n* ]]; then
+    if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+      printf "\\"%s\\"\\n" "$input" 
+    elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+      printf "\`%s\`\\n" "$input"
+    elif [[ "$input" == *\\"* ]]; then
+      printf "'%s'\\n" "$input"
+    else
+      printf "\\"%s\\"\\n" "$input"
+    fi
+  else
+    printf "%s\\n" "$input"
+  fi
+}
+function collapseable_section_start () {
+local section_title="\${1}"
+  local section_description="\${2:-$section_title}"
+  echo "::group::\${section_description}"
+}
+function collapseable_section_end () {
+echo "::endgroup::"
+}
+collapseable_section_start "injectvars" "Injecting variables"
+export ENV_SHORT="next"
+export APP_DIR="www"
+export ENV_TYPE="dev"
+export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+export BUILD_INFO_BUILD_TIME="unknown-build-time"
+export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+export HOSTNAME="pan-test-app-next-www-123456789012.europe-west6.run.app"
+export ROOT_URL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+export HOSTNAME_INTERNAL="pan-test-app-next-www-123456789012.europe-west6.run.app"
+export ROOT_URL_INTERNAL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-next-www"
+export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+export GCLOUD_DEPLOY_credentialsKey="$CL_next_www_GCLOUD_DEPLOY_credentialsKey"
+export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www"
+export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+export DOCKER_IMAGE_TAG="$GITHUB_SHA"
+export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+collapseable_section_end "injectvars"
+collapseable_section_start "prepare" "Prepare..."
+gcloud auth activate-service-account --key-file=<(echo "$CL_next_www_GCLOUD_DEPLOY_credentialsKey")
+collapseable_section_end "prepare"
+collapseable_section_start "writeenvvars" "Write env vars to file"
+cat > ____envvars.yaml <<EOF
+ENV_SHORT: |-
+  next
+APP_DIR: |-
+  www
+ENV_TYPE: |-
+  dev
+BUILD_INFO_BUILD_ID: |-
+  $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+BUILD_INFO_BUILD_TIME: |-
+  unknown-build-time
+BUILD_INFO_CURRENT_VERSION: |-
+  $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+HOSTNAME: |-
+  pan-test-app-next-www-123456789012.europe-west6.run.app
+ROOT_URL: |-
+  https://pan-test-app-next-www-123456789012.europe-west6.run.app
+HOSTNAME_INTERNAL: |-
+  pan-test-app-next-www-123456789012.europe-west6.run.app
+ROOT_URL_INTERNAL: |-
+  https://pan-test-app-next-www-123456789012.europe-west6.run.app
+DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+  pan-test-app-next-www
+DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+  google-project-id
+DEPLOY_CLOUD_RUN_REGION: |-
+  europe-west6
+_ALL_ENV_VAR_KEYS: |-
+  ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+EOF
+
+collapseable_section_end "writeenvvars"
+collapseable_section_start "deploy" "Deploy to cloud run"
+gcloud run deploy pan-test-app-next-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=dev,env-name=next,build-type=node,cloud-run-service-name=pan-test-app-next-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+collapseable_section_end "deploy"
+collapseable_section_start "cleanup" "Cleanup"
+set +e
+gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-next-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www@$version --quiet --delete-tags; done
+gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+set -e
+collapseable_section_end "cleanup"
+echo "url=$ROOT_URL" >> "$GITHUB_OUTPUT"
+"
+`;
+
+exports[`matches snapshot for env-triggers local pipeline YAML 1`] = `
+"image: node:22
+stages:
+  - setup
+  - setup dev
+  - setup review
+  - setup stage
+  - setup prod
+  - setup next
+  - test
+  - test dev
+  - test review
+  - test stage
+  - test prod
+  - test next
+  - build
+  - build dev
+  - build review
+  - build stage
+  - build prod
+  - build next
+  - deploy
+  - deploy dev
+  - deploy review
+  - deploy stage
+  - deploy prod
+  - deploy next
+  - verify
+  - verify dev
+  - verify review
+  - verify stage
+  - verify prod
+  - verify next
+  - agents
+  - agents dev
+  - agents review
+  - agents stage
+  - agents prod
+  - agents next
+  - rollback
+  - rollback dev
+  - rollback review
+  - rollback stage
+  - rollback prod
+  - rollback next
+  - stop
+  - stop dev
+  - stop review
+  - stop stage
+  - stop prod
+  - stop next
+  - release
+variables:
+  FF_USE_FASTZIP: 'true'
+  ARTIFACT_COMPRESSION_LEVEL: fast
+  CACHE_COMPRESSION_LEVEL: fast
+  TRANSFER_METER_FREQUENCY: 5s
+  GIT_DEPTH: '1'
+workflow:
+  name: $PIPELINE_ICON $PIPELINE_NAME
+  rules:
+    - if: $CI_PIPELINE_SOURCE  == "trigger"
+      variables:
+        PIPELINE_ICON: 🤖
+        PIPELINE_NAME: Thinking...
+    - if: $CI_MERGE_REQUEST_ID
+      variables:
+        PIPELINE_ICON: 🐱🔨
+        PIPELINE_NAME: mr$CI_MERGE_REQUEST_IID - $CI_MERGE_REQUEST_TITLE
+    - if: $CI_COMMIT_TAG
+      variables:
+        PIPELINE_ICON: 🐱📦
+        PIPELINE_NAME: Release $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+      variables:
+        PIPELINE_ICON: 🐱🔨
+        PIPELINE_NAME: Main - $CI_COMMIT_TITLE
+    - if: $CI_COMMIT_BRANCH == "next"
+      variables:
+        PIPELINE_ICON: 🐱🔨
+        PIPELINE_NAME: next - $CI_COMMIT_TITLE
+    - when: always
+      variables:
+        PIPELINE_ICON: 🐱❓
+        PIPELINE_NAME: Default
+before_script:
+  - |-
+    function escapeForDotEnv () {
+    input="\${1:-$(cat)}"
+     input="\${input//$'\\n'/\\\\n}"
+      if [[ "$input" == *\\\\n* ]]; then
+        if [[ "$input" == *\\"* && "$input" == *\\'* && "$input" == *\\\`* ]]; then
+          printf "\\"%s\\"\\n" "$input" 
+        elif [[ "$input" == *\\"* && "$input" == *\\'* ]]; then
+          printf "\`%s\`\\n" "$input"
+        elif [[ "$input" == *\\"* ]]; then
+          printf "'%s'\\n" "$input"
+        else
+          printf "\\"%s\\"\\n" "$input"
+        fi
+      else
+        printf "%s\\n" "$input"
+      fi
+    }
+  - |-
+    function collapseable_section_start () {
+    local section_title="\${1}"
+      local section_description="\${2:-$section_title}"
+      echo -e "section_start:\`date +%s\`:\${section_title}[collapsed=true]\\r\\e[0K\${section_description}"
+    }
+  - |-
+    function collapseable_section_end () {
+    local section_title="\${1}"
+      echo -e "section_end:\`date +%s\`:\${section_title}\\r\\e[0K"
+    }
+🐳 catladder image semantic-release:
+  stage: setup
+  image: docker.io/docker:29.5.1
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+  script:
+    - collapseable_section_start "docker-login" "Docker Login"
+    - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "check-image" "Checking if image exists"
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e already exists, skipping build"'
+    - '  exit 0'
+    - fi
+    - collapseable_section_end "check-image"
+    - collapseable_section_start "docker-build" "Building image"
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e -f .catladder-generated/images/semantic-release/Dockerfile .catladder-generated/images/semantic-release
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Pushing image"
+    - docker push $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
+    - collapseable_section_end "docker-push"
+  rules:
+    - &a1
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+      when: never
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+      changes:
+        - .catladder-generated/images/semantic-release/**/*
+    - *a1
+    - if: $CI_MERGE_REQUEST_ID
+      changes:
+        - .catladder-generated/images/semantic-release/**/*
+    - *a1
+    - if: $CI_COMMIT_TAG
+      changes:
+        - .catladder-generated/images/semantic-release/**/*
+    - *a1
+    - if: $CI_COMMIT_BRANCH == "next"
+      changes:
+        - .catladder-generated/images/semantic-release/**/*
+  needs: []
+  retry: &a2
+    max: 2
+  interruptible: true
+🐳 catladder image jobs-default:
+  stage: setup
+  image: docker.io/docker:29.5.1
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+  script:
+    - collapseable_section_start "docker-login" "Docker Login"
+    - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "check-image" "Checking if image exists"
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df already exists, skipping build"'
+    - '  exit 0'
+    - fi
+    - collapseable_section_end "check-image"
+    - collapseable_section_start "docker-build" "Building image"
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df -f .catladder-generated/images/jobs-default/Dockerfile .catladder-generated/images
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Pushing image"
+    - docker push $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+    - collapseable_section_end "docker-push"
+  rules:
+    - *a1
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+      changes:
+        - .catladder-generated/images/jobs-default/**/*
+    - *a1
+    - if: $CI_MERGE_REQUEST_ID
+      changes:
+        - .catladder-generated/images/jobs-default/**/*
+    - *a1
+    - if: $CI_COMMIT_TAG
+      changes:
+        - .catladder-generated/images/jobs-default/**/*
+    - *a1
+    - if: $CI_COMMIT_BRANCH == "next"
+      changes:
+        - .catladder-generated/images/jobs-default/**/*
+  needs: []
+  retry: *a2
+  interruptible: true
+🐳 catladder image docker-build:
+  stage: setup
+  image: docker.io/docker:29.5.1
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+  script:
+    - collapseable_section_start "docker-login" "Docker Login"
+    - docker login --username $CI_REGISTRY_USER --password $CI_JOB_TOKEN $CI_REGISTRY
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "check-image" "Checking if image exists"
+    - if docker manifest inspect $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e > /dev/null 2>&1; then
+    - '  echo "Image $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e already exists, skipping build"'
+    - '  exit 0'
+    - fi
+    - collapseable_section_end "check-image"
+    - collapseable_section_start "docker-build" "Building image"
+    - DOCKER_BUILDKIT=1 docker build -t $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e -f .catladder-generated/images/docker-build/Dockerfile .catladder-generated/images/docker-build
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Pushing image"
+    - docker push $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e
+    - collapseable_section_end "docker-push"
+  rules:
+    - *a1
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+      changes:
+        - .catladder-generated/images/docker-build/**/*
+    - *a1
+    - if: $CI_MERGE_REQUEST_ID
+      changes:
+        - .catladder-generated/images/docker-build/**/*
+    - *a1
+    - if: $CI_COMMIT_TAG
+      changes:
+        - .catladder-generated/images/docker-build/**/*
+    - *a1
+    - if: $CI_COMMIT_BRANCH == "next"
+      changes:
+        - .catladder-generated/images/docker-build/**/*
+  needs: []
+  retry: *a2
+  interruptible: true
+create release:
+  stage: release
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
+  script:
+    - echo "release queued — '🚀 release once pipeline succeeds' runs it as soon as every other job in this pipeline succeeded"
+  rules: &a7
+    - &a3
+      if: $CI_COMMIT_MESSAGE =~ /^chore\\(release\\).*/
+      when: never
+    - *a1
+    - &a4
+      if: $CI_PIPELINE_SOURCE  == "schedule"
+      when: never
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: manual
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+.([0-9]+|x).x$/
+      when: manual
+  needs: []
+  allow_failure: true
+🚀 release once pipeline succeeds:
+  stage: release
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
+  script: &a5
+    - semanticRelease
+  after_script: &a6
+    - echo '👉 If this job failed with access denied, the project access token might be invald - run \`project-renew-token\` in catladder CLI to fix.'
+  rules:
+    - *a3
+    - *a1
+    - *a4
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: on_success
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+.([0-9]+|x).x$/
+      when: on_success
+  needs:
+    - job: create release
+    - job: 🐳 catladder image semantic-release
+      optional: true
+    - job: 'www 🚀 Deploy | dev '
+      optional: true
+⚠️ force create release:
+  stage: release
+  image: $CI_REGISTRY_IMAGE/catladder/semantic-release:21a7a48f5d1e
+  script: *a5
+  after_script: *a6
+  rules: *a7
+  needs: []
+  allow_failure: true
+'www 🛡 audit | dev ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - cd www
+    - yarn npm audit --environment production --severity critical --all --recursive
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 👮 lint | dev ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn lint
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull
+      paths: &a8
+        - www/node_modules
+        - www/.yarn/install-state.gz
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🧪 test | dev ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn test
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull
+      paths: *a8
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 app | dev ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="dev"
+    - export APP_DIR="www"
+    - export ENV_TYPE="dev"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-dev-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_dev_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "write-dotenv-www" "write dot env for www"
+    - |-
+      cat <<EOF > www/.env
+      ENV_SHORT=dev
+      APP_DIR=www
+      ENV_TYPE=dev
+      HOSTNAME=pan-test-app-dev-www-123456789012.europe-west6.run.app
+      ROOT_URL=https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL=pan-test-app-dev-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL=https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-dev-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+      DEPLOY_CLOUD_RUN_REGION=europe-west6
+      GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+      _ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+      EOF
+    - collapseable_section_end "write-dotenv-www"
+    - echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"$CI_JOB_STARTED_AT"}' > www/__build_info.json
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn build
+  cache:
+    - key: www-yarn
+      policy: pull-push
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull-push
+      paths:
+        - www/node_modules
+        - www/.yarn/install-state.gz
+  artifacts:
+    paths:
+      - www/__build_info.json
+      - www/.next
+      - www/dist
+    exclude:
+      - www/.env
+      - www/.next/cache/**/*
+    expire_in: 1 day
+    when: always
+    reports: {}
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 docker | dev ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 2Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_DIR="www"
+    - export DOCKER_BUILD_CONTEXT="."
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - |-
+      export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+      COPY --chown=node:node $APP_DIR .
+      RUN yarn plugin import workspace-tools
+      RUN yarn workspaces focus --production
+      RUN yarn rebuild"
+    - |-
+      export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+      COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+      COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+      COPY --chown=node:node .yarn /app/.yarn"
+    - collapseable_section_end "injectvars"
+    - ensureNodeDockerfile
+    - collapseable_section_start "docker-login" "Docker Login"
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud auth configure-docker europe-west6-docker.pkg.dev
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "docker-build" "Docker build"
+    - docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Docker push and tag"
+    - docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+    - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+    - docker push $DOCKER_CACHE_IMAGE
+    - collapseable_section_end "docker-push"
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+  needs:
+    - job: 🐳 catladder image docker-build
+      artifacts: false
+      optional: true
+    - 'www 🔨 app | dev '
+  retry: *a2
+  interruptible: true
+'www 🚀 Deploy | dev ':
+  stage: deploy dev
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="dev"
+    - export APP_DIR="www"
+    - export ENV_TYPE="dev"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-dev-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-dev-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_dev_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "prepare" "Prepare..."
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey")
+    - collapseable_section_end "prepare"
+    - collapseable_section_start "writeenvvars" "Write env vars to file"
+    - |
+      cat > ____envvars.yaml <<EOF
+      ENV_SHORT: |-
+        dev
+      APP_DIR: |-
+        www
+      ENV_TYPE: |-
+        dev
+      BUILD_INFO_BUILD_ID: |-
+        $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+      BUILD_INFO_BUILD_TIME: |-
+        $(printf %s "$CI_JOB_STARTED_AT" | sed '1!s/^/  /')
+      BUILD_INFO_CURRENT_VERSION: |-
+        $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+      HOSTNAME: |-
+        pan-test-app-dev-www-123456789012.europe-west6.run.app
+      ROOT_URL: |-
+        https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL: |-
+        pan-test-app-dev-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL: |-
+        https://pan-test-app-dev-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+        pan-test-app-dev-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+        google-project-id
+      DEPLOY_CLOUD_RUN_REGION: |-
+        europe-west6
+      _ALL_ENV_VAR_KEYS: |-
+        ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+      EOF
+    - collapseable_section_end "writeenvvars"
+    - collapseable_section_start "deploy" "Deploy to cloud run"
+    - gcloud run deploy pan-test-app-dev-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=dev,env-name=dev,build-type=node,cloud-run-service-name=pan-test-app-dev-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+    - collapseable_section_end "deploy"
+    - collapseable_section_start "cleanup" "Cleanup"
+    - set +e
+    - gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-dev-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www@$version --quiet --delete-tags; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+    - collapseable_section_end "cleanup"
+    - echo "CL_GITLAB_ENVIRONMENT_URL=$ROOT_URL" >> gitlab_environment.env
+  environment:
+    name: dev/www
+    url: $CL_GITLAB_ENVIRONMENT_URL
+    on_stop: 'www 🛑 Stop ⚠️ | dev '
+  artifacts:
+    reports:
+      dotenv: gitlab_environment.env
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: on_success
+      if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+  needs:
+    - job: 'www 👮 lint | dev '
+      artifacts: false
+    - job: 'www 🔨 app | dev '
+      artifacts: false
+    - job: 'www 🔨 docker | dev '
+      artifacts: false
+    - job: 'www 🧪 test | dev '
+      artifacts: false
+    - job: 'www 🛡 audit | dev '
+      artifacts: false
+  retry: *a2
+  interruptible: true
+  allow_failure: false
+'www 🛑 Stop ⚠️ | dev ':
+  stage: stop dev
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+    GIT_STRATEGY: none
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - set +e
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_dev_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud run services delete pan-test-app-dev-www --project=google-project-id --region=europe-west6
+    - gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/dev/www --quiet --delete-tags
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+  environment:
+    name: dev/www
+    action: stop
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: manual
+      if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && ($CI_COMMIT_MESSAGE !~ /^chore\\(release\\).*/ || $CI_PIPELINE_SOURCE != "push")
+  needs: []
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 🛡 audit | review ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - cd www
+    - yarn npm audit --environment production --severity critical --all --recursive
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_MERGE_REQUEST_ID
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 👮 lint | review ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn lint
+  cache:
+    - key: www-yarn-mr$CI_MERGE_REQUEST_IID
+      policy: pull
+      paths:
+        - www/.yarn
+      fallback_keys:
+        - www-yarn
+    - key: www-node-modules-mr$CI_MERGE_REQUEST_IID
+      policy: pull
+      paths: &a9
+        - www/node_modules
+        - www/.yarn/install-state.gz
+      fallback_keys:
+        - www-node-modules
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_MERGE_REQUEST_ID
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🧪 test | review ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn test
+  cache:
+    - key: www-yarn-mr$CI_MERGE_REQUEST_IID
+      policy: pull
+      paths:
+        - www/.yarn
+      fallback_keys:
+        - www-yarn
+    - key: www-node-modules-mr$CI_MERGE_REQUEST_IID
+      policy: pull
+      paths: *a9
+      fallback_keys:
+        - www-node-modules
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_MERGE_REQUEST_ID
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 app | review ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="review"
+    - export APP_DIR="www"
+    - export ENV_TYPE="review"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export ROOT_URL="https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export HOSTNAME_INTERNAL="$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export ROOT_URL_INTERNAL="https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}')"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_review_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "write-dotenv-www" "write dot env for www"
+    - |-
+      cat <<EOF > www/.env
+      ENV_SHORT=review
+      APP_DIR=www
+      ENV_TYPE=review
+      HOSTNAME=$(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+      ROOT_URL=$(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+      HOSTNAME_INTERNAL=$(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+      ROOT_URL_INTERNAL=$(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | escapeForDotEnv)
+      DEPLOY_CLOUD_RUN_SERVICE_NAME=$(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}')" | escapeForDotEnv)
+      DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+      DEPLOY_CLOUD_RUN_REGION=europe-west6
+      GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_review_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+      _ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+      EOF
+    - collapseable_section_end "write-dotenv-www"
+    - echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"$CI_JOB_STARTED_AT"}' > www/__build_info.json
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn build
+  cache:
+    - key: www-yarn-mr$CI_MERGE_REQUEST_IID
+      policy: pull-push
+      paths:
+        - www/.yarn
+      fallback_keys:
+        - www-yarn
+    - key: www-node-modules-mr$CI_MERGE_REQUEST_IID
+      policy: pull-push
+      paths:
+        - www/node_modules
+        - www/.yarn/install-state.gz
+      fallback_keys:
+        - www-node-modules
+  artifacts:
+    paths:
+      - www/__build_info.json
+      - www/.next
+      - www/dist
+    exclude:
+      - www/.env
+      - www/.next/cache/**/*
+    expire_in: 1 day
+    when: always
+    reports: {}
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_MERGE_REQUEST_ID
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 docker | review ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 2Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_DIR="www"
+    - export DOCKER_BUILD_CONTEXT="."
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - |-
+      export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+      COPY --chown=node:node $APP_DIR .
+      RUN yarn plugin import workspace-tools
+      RUN yarn workspaces focus --production
+      RUN yarn rebuild"
+    - |-
+      export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+      COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+      COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+      COPY --chown=node:node .yarn /app/.yarn"
+    - collapseable_section_end "injectvars"
+    - ensureNodeDockerfile
+    - collapseable_section_start "docker-login" "Docker Login"
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_review_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud auth configure-docker europe-west6-docker.pkg.dev
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "docker-build" "Docker build"
+    - docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Docker push and tag"
+    - docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+    - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+    - docker push $DOCKER_CACHE_IMAGE
+    - collapseable_section_end "docker-push"
+  cache:
+    - key: www-yarn-mr$CI_MERGE_REQUEST_IID
+      policy: pull
+      paths:
+        - www/.yarn
+      fallback_keys:
+        - www-yarn
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_MERGE_REQUEST_ID
+  needs:
+    - job: 🐳 catladder image docker-build
+      artifacts: false
+      optional: true
+    - 'www 🔨 app | review '
+  retry: *a2
+  interruptible: true
+'www 🚀 Deploy | review ':
+  stage: deploy review
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="review"
+    - export APP_DIR="www"
+    - export ENV_TYPE="review"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export ROOT_URL="https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export HOSTNAME_INTERNAL="$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export ROOT_URL_INTERNAL="https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}')"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_review_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "prepare" "Prepare..."
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_review_www_GCLOUD_DEPLOY_credentialsKey")
+    - collapseable_section_end "prepare"
+    - collapseable_section_start "writeenvvars" "Write env vars to file"
+    - |
+      cat > ____envvars.yaml <<EOF
+      ENV_SHORT: |-
+        review
+      APP_DIR: |-
+        www
+      ENV_TYPE: |-
+        review
+      BUILD_INFO_BUILD_ID: |-
+        $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+      BUILD_INFO_BUILD_TIME: |-
+        $(printf %s "$CI_JOB_STARTED_AT" | sed '1!s/^/  /')
+      BUILD_INFO_CURRENT_VERSION: |-
+        $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+      HOSTNAME: |-
+        $(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+      ROOT_URL: |-
+        $(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+      HOSTNAME_INTERNAL: |-
+        $(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+      ROOT_URL_INTERNAL: |-
+        $(printf %s "https://$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www-123456789012.europe-west6.run.app" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+      DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+        $(printf %s "$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}')" | sed '1!s/^/  /')
+      DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+        google-project-id
+      DEPLOY_CLOUD_RUN_REGION: |-
+        europe-west6
+      _ALL_ENV_VAR_KEYS: |-
+        ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+      EOF
+    - collapseable_section_end "writeenvvars"
+    - collapseable_section_start "deploy" "Deploy to cloud run"
+    - gcloud run deploy $(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}') --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; }):$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=review,env-name=review,build-type=node,cloud-run-service-name=$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}') --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+    - collapseable_section_end "deploy"
+    - collapseable_section_start "cleanup" "Cleanup"
+    - set +e
+    - gcloud run revisions list --project=google-project-id --region=europe-west6 --service=$(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}') --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; }) --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })@$version --quiet --delete-tags; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set +e
+    - gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www --quiet --delete-tags
+    - set -e
+    - set -e
+    - collapseable_section_end "cleanup"
+    - echo "CL_GITLAB_ENVIRONMENT_URL=$ROOT_URL" >> gitlab_environment.env
+  environment:
+    name: review/$CI_COMMIT_REF_NAME/www
+    url: $CL_GITLAB_ENVIRONMENT_URL
+    on_stop: 'www 🛑 Stop ⚠️ | review '
+    auto_stop_in: 3 days
+  artifacts:
+    reports:
+      dotenv: gitlab_environment.env
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: on_success
+      if: $CI_MERGE_REQUEST_ID
+  needs:
+    - job: 'www 👮 lint | review '
+      artifacts: false
+    - job: 'www 🔨 app | review '
+      artifacts: false
+    - job: 'www 🔨 docker | review '
+      artifacts: false
+    - job: 'www 🧪 test | review '
+      artifacts: false
+    - job: 'www 🛡 audit | review '
+      artifacts: false
+  retry: *a2
+  interruptible: true
+  allow_failure: false
+'www 🛑 Stop ⚠️ | review ':
+  stage: stop review
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+    GIT_STRATEGY: none
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - set +e
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_review_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud run services delete $(printf %s "pan-test-app-review-$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; })-www" | awk '{print tolower($0)}') --project=google-project-id --region=europe-west6
+    - gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www/$([ -n "$CI_MERGE_REQUEST_IID" ] && echo "mr$CI_MERGE_REQUEST_IID" || { [ -n "$CI_COMMIT_REF_SLUG" ] && echo "$CI_COMMIT_REF_SLUG" || echo "unknown"; }) --quiet --delete-tags
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set +e
+    - gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/review/www --quiet --delete-tags
+    - set -e
+    - set -e
+  environment:
+    name: review/$CI_COMMIT_REF_NAME/www
+    action: stop
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: manual
+      if: $CI_MERGE_REQUEST_ID
+  needs: []
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 🔨 app | stage ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="stage"
+    - export APP_DIR="www"
+    - export ENV_TYPE="stage"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-stage-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_stage_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "write-dotenv-www" "write dot env for www"
+    - |-
+      cat <<EOF > www/.env
+      ENV_SHORT=stage
+      APP_DIR=www
+      ENV_TYPE=stage
+      HOSTNAME=pan-test-app-stage-www-123456789012.europe-west6.run.app
+      ROOT_URL=https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL=pan-test-app-stage-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL=https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-stage-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+      DEPLOY_CLOUD_RUN_REGION=europe-west6
+      GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+      _ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+      EOF
+    - collapseable_section_end "write-dotenv-www"
+    - echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"$CI_JOB_STARTED_AT"}' > www/__build_info.json
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn build
+  cache:
+    - key: www-yarn
+      policy: pull-push
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull-push
+      paths:
+        - www/node_modules
+        - www/.yarn/install-state.gz
+  artifacts:
+    paths:
+      - www/__build_info.json
+      - www/.next
+      - www/dist
+    exclude:
+      - www/.env
+      - www/.next/cache/**/*
+    expire_in: 1 day
+    when: always
+    reports: {}
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_TAG
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 docker | stage ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 2Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_DIR="www"
+    - export DOCKER_BUILD_CONTEXT="."
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - |-
+      export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+      COPY --chown=node:node $APP_DIR .
+      RUN yarn plugin import workspace-tools
+      RUN yarn workspaces focus --production
+      RUN yarn rebuild"
+    - |-
+      export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+      COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+      COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+      COPY --chown=node:node .yarn /app/.yarn"
+    - collapseable_section_end "injectvars"
+    - ensureNodeDockerfile
+    - collapseable_section_start "docker-login" "Docker Login"
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud auth configure-docker europe-west6-docker.pkg.dev
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "docker-build" "Docker build"
+    - docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Docker push and tag"
+    - docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+    - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+    - docker push $DOCKER_CACHE_IMAGE
+    - collapseable_section_end "docker-push"
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_TAG
+  needs:
+    - job: 🐳 catladder image docker-build
+      artifacts: false
+      optional: true
+    - 'www 🔨 app | stage '
+  retry: *a2
+  interruptible: true
+'www 🚀 Deploy | stage ':
+  stage: deploy stage
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="stage"
+    - export APP_DIR="www"
+    - export ENV_TYPE="stage"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-stage-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-stage-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_stage_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "prepare" "Prepare..."
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey")
+    - collapseable_section_end "prepare"
+    - collapseable_section_start "writeenvvars" "Write env vars to file"
+    - |
+      cat > ____envvars.yaml <<EOF
+      ENV_SHORT: |-
+        stage
+      APP_DIR: |-
+        www
+      ENV_TYPE: |-
+        stage
+      BUILD_INFO_BUILD_ID: |-
+        $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+      BUILD_INFO_BUILD_TIME: |-
+        $(printf %s "$CI_JOB_STARTED_AT" | sed '1!s/^/  /')
+      BUILD_INFO_CURRENT_VERSION: |-
+        $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+      HOSTNAME: |-
+        pan-test-app-stage-www-123456789012.europe-west6.run.app
+      ROOT_URL: |-
+        https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL: |-
+        pan-test-app-stage-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL: |-
+        https://pan-test-app-stage-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+        pan-test-app-stage-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+        google-project-id
+      DEPLOY_CLOUD_RUN_REGION: |-
+        europe-west6
+      _ALL_ENV_VAR_KEYS: |-
+        ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+      EOF
+    - collapseable_section_end "writeenvvars"
+    - collapseable_section_start "deploy" "Deploy to cloud run"
+    - gcloud run deploy pan-test-app-stage-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=stage,env-name=stage,build-type=node,cloud-run-service-name=pan-test-app-stage-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+    - collapseable_section_end "deploy"
+    - collapseable_section_start "cleanup" "Cleanup"
+    - set +e
+    - gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-stage-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www@$version --quiet --delete-tags; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+    - collapseable_section_end "cleanup"
+    - echo "CL_GITLAB_ENVIRONMENT_URL=$ROOT_URL" >> gitlab_environment.env
+  environment:
+    name: stage/www
+    url: $CL_GITLAB_ENVIRONMENT_URL
+    on_stop: 'www 🛑 Stop ⚠️ | stage '
+  artifacts:
+    reports:
+      dotenv: gitlab_environment.env
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: on_success
+      if: $CI_COMMIT_TAG
+  needs:
+    - job: 'www 🔨 app | stage '
+      artifacts: false
+    - job: 'www 🔨 docker | stage '
+      artifacts: false
+  retry: *a2
+  interruptible: true
+  allow_failure: false
+'www 🛑 Stop ⚠️ | stage ':
+  stage: stop stage
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+    GIT_STRATEGY: none
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - set +e
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_stage_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud run services delete pan-test-app-stage-www --project=google-project-id --region=europe-west6
+    - gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/stage/www --quiet --delete-tags
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+  environment:
+    name: stage/www
+    action: stop
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: manual
+      if: $CI_COMMIT_TAG
+  needs: []
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 🔨 app | prod ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="prod"
+    - export APP_DIR="www"
+    - export ENV_TYPE="prod"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-prod-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_prod_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "write-dotenv-www" "write dot env for www"
+    - |-
+      cat <<EOF > www/.env
+      ENV_SHORT=prod
+      APP_DIR=www
+      ENV_TYPE=prod
+      HOSTNAME=pan-test-app-prod-www-123456789012.europe-west6.run.app
+      ROOT_URL=https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL=pan-test-app-prod-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL=https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-prod-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+      DEPLOY_CLOUD_RUN_REGION=europe-west6
+      GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+      _ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+      EOF
+    - collapseable_section_end "write-dotenv-www"
+    - echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"$CI_JOB_STARTED_AT"}' > www/__build_info.json
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn build
+  cache:
+    - key: www-yarn
+      policy: pull-push
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull-push
+      paths:
+        - www/node_modules
+        - www/.yarn/install-state.gz
+  artifacts:
+    paths:
+      - www/__build_info.json
+      - www/.next
+      - www/dist
+    exclude:
+      - www/.env
+      - www/.next/cache/**/*
+    expire_in: 1 day
+    when: always
+    reports: {}
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_TAG
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 docker | prod ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 2Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_DIR="www"
+    - export DOCKER_BUILD_CONTEXT="."
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - |-
+      export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+      COPY --chown=node:node $APP_DIR .
+      RUN yarn plugin import workspace-tools
+      RUN yarn workspaces focus --production
+      RUN yarn rebuild"
+    - |-
+      export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+      COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+      COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+      COPY --chown=node:node .yarn /app/.yarn"
+    - collapseable_section_end "injectvars"
+    - ensureNodeDockerfile
+    - collapseable_section_start "docker-login" "Docker Login"
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud auth configure-docker europe-west6-docker.pkg.dev
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "docker-build" "Docker build"
+    - docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Docker push and tag"
+    - docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+    - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+    - docker push $DOCKER_CACHE_IMAGE
+    - collapseable_section_end "docker-push"
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_TAG
+  needs:
+    - job: 🐳 catladder image docker-build
+      artifacts: false
+      optional: true
+    - 'www 🔨 app | prod '
+  retry: *a2
+  interruptible: true
+'www 🚀 Deploy | prod ':
+  stage: deploy prod
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="prod"
+    - export APP_DIR="www"
+    - export ENV_TYPE="prod"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-prod-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-prod-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_prod_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "prepare" "Prepare..."
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey")
+    - collapseable_section_end "prepare"
+    - collapseable_section_start "writeenvvars" "Write env vars to file"
+    - |
+      cat > ____envvars.yaml <<EOF
+      ENV_SHORT: |-
+        prod
+      APP_DIR: |-
+        www
+      ENV_TYPE: |-
+        prod
+      BUILD_INFO_BUILD_ID: |-
+        $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+      BUILD_INFO_BUILD_TIME: |-
+        $(printf %s "$CI_JOB_STARTED_AT" | sed '1!s/^/  /')
+      BUILD_INFO_CURRENT_VERSION: |-
+        $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+      HOSTNAME: |-
+        pan-test-app-prod-www-123456789012.europe-west6.run.app
+      ROOT_URL: |-
+        https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL: |-
+        pan-test-app-prod-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL: |-
+        https://pan-test-app-prod-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+        pan-test-app-prod-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+        google-project-id
+      DEPLOY_CLOUD_RUN_REGION: |-
+        europe-west6
+      _ALL_ENV_VAR_KEYS: |-
+        ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+      EOF
+    - collapseable_section_end "writeenvvars"
+    - collapseable_section_start "deploy" "Deploy to cloud run"
+    - gcloud run deploy pan-test-app-prod-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=prod,env-name=prod,build-type=node,cloud-run-service-name=pan-test-app-prod-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+    - collapseable_section_end "deploy"
+    - collapseable_section_start "cleanup" "Cleanup"
+    - set +e
+    - gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-prod-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | tail -n +3 | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +4 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www@$version --quiet --delete-tags; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+    - collapseable_section_end "cleanup"
+    - echo "CL_GITLAB_ENVIRONMENT_URL=$ROOT_URL" >> gitlab_environment.env
+  environment:
+    name: prod/www
+    url: $CL_GITLAB_ENVIRONMENT_URL
+    on_stop: 'www 🛑 Stop ⚠️ | prod '
+  artifacts:
+    reports:
+      dotenv: gitlab_environment.env
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: manual
+      if: $CI_COMMIT_TAG
+  needs:
+    - job: 'www 🔨 app | prod '
+      artifacts: false
+    - job: 'www 🔨 docker | prod '
+      artifacts: false
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 🛑 Stop ⚠️ | prod ':
+  stage: stop prod
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+    GIT_STRATEGY: none
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - set +e
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_prod_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud run services delete pan-test-app-prod-www --project=google-project-id --region=europe-west6
+    - gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/prod/www --quiet --delete-tags
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+  environment:
+    name: prod/www
+    action: stop
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: manual
+      if: $CI_COMMIT_TAG
+  needs: []
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 🛡 audit | next ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - cd www
+    - yarn npm audit --environment production --severity critical --all --recursive
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == "next"
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+'www 👮 lint | next ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn lint
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull
+      paths: &a10
+        - www/node_modules
+        - www/.yarn/install-state.gz
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == "next"
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🧪 test | next ':
+  stage: test
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_PATH="www"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn test
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull
+      paths: *a10
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == "next"
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 app | next ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/jobs-default:8c93778931df
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="next"
+    - export APP_DIR="www"
+    - export ENV_TYPE="dev"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-next-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_next_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "write-dotenv-www" "write dot env for www"
+    - |-
+      cat <<EOF > www/.env
+      ENV_SHORT=next
+      APP_DIR=www
+      ENV_TYPE=dev
+      HOSTNAME=pan-test-app-next-www-123456789012.europe-west6.run.app
+      ROOT_URL=https://pan-test-app-next-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL=pan-test-app-next-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL=https://pan-test-app-next-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME=pan-test-app-next-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID=google-project-id
+      DEPLOY_CLOUD_RUN_REGION=europe-west6
+      GCLOUD_DEPLOY_credentialsKey=$(printf %s "$CL_next_www_GCLOUD_DEPLOY_credentialsKey" | escapeForDotEnv)
+      _ALL_ENV_VAR_KEYS=["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+      EOF
+    - collapseable_section_end "write-dotenv-www"
+    - echo '{"id":"$(git describe --tags 2>/dev/null || git rev-parse HEAD)","time":"$CI_JOB_STARTED_AT"}' > www/__build_info.json
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - cd www
+    - collapseable_section_start "nodeinstall" "Ensure node version"
+    - if [ -f "$HOME/.nvm/nvm.sh" ]; then source "$HOME/.nvm/nvm.sh"; elif [ -f /root/.nvm/nvm.sh ]; then export NVM_DIR=/root/.nvm; source /root/.nvm/nvm.sh; fi
+    - if command -v nvm &> /dev/null && [ -f ./.nvmrc ]; then nvm install; fi
+    - collapseable_section_end "nodeinstall"
+    - collapseable_section_start "yarninstall" "Yarn install"
+    - yarn install --immutable --inline-builds
+    - collapseable_section_end "yarninstall"
+    - yarn build
+  cache:
+    - key: www-yarn
+      policy: pull-push
+      paths:
+        - www/.yarn
+    - key: www-node-modules
+      policy: pull-push
+      paths:
+        - www/node_modules
+        - www/.yarn/install-state.gz
+  artifacts:
+    paths:
+      - www/__build_info.json
+      - www/.next
+      - www/dist
+    exclude:
+      - www/.env
+      - www/.next/cache/**/*
+    expire_in: 1 day
+    when: always
+    reports: {}
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == "next"
+  needs:
+    - job: 🐳 catladder image jobs-default
+      artifacts: false
+      optional: true
+  retry: *a2
+  interruptible: true
+'www 🔨 docker | next ':
+  stage: build
+  image: $CI_REGISTRY_IMAGE/catladder/docker-build:b343b099980e
+  services:
+    - name: docker:29.5.1-dind
+      command:
+        - --tls=false
+        - --registry-mirror=https://mirror.gcr.io
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ''
+    DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: '1'
+    KUBERNETES_CPU_REQUEST: '0.45'
+    KUBERNETES_MEMORY_REQUEST: 1Gi
+    KUBERNETES_MEMORY_LIMIT: 2Gi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export APP_DIR="www"
+    - export DOCKER_BUILD_CONTEXT="."
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - |-
+      export DOCKER_COPY_AND_INSTALL_APP="ENV YARN_ENABLE_INLINE_BUILDS=1
+      COPY --chown=node:node $APP_DIR .
+      RUN yarn plugin import workspace-tools
+      RUN yarn workspaces focus --production
+      RUN yarn rebuild"
+    - |-
+      export DOCKER_COPY_WORKSPACE_FILES="COPY --chown=node:node www/package.json /app/www/package.json
+      COPY --chown=node:node www/yarn.lock /app/www/yarn.lock
+      COPY --chown=node:node .yarnrc.yml /app/.yarnrc.yml
+      COPY --chown=node:node .yarn /app/.yarn"
+    - collapseable_section_end "injectvars"
+    - ensureNodeDockerfile
+    - collapseable_section_start "docker-login" "Docker Login"
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_next_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud auth configure-docker europe-west6-docker.pkg.dev
+    - collapseable_section_end "docker-login"
+    - collapseable_section_start "docker-build" "Docker build"
+    - docker build --network host --cache-from $DOCKER_CACHE_IMAGE --tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG -f $APP_DIR/Dockerfile $DOCKER_BUILD_CONTEXT --build-arg BUILDKIT_INLINE_CACHE=1
+    - collapseable_section_end "docker-build"
+    - collapseable_section_start "docker-push" "Docker push and tag"
+    - docker push $DOCKER_IMAGE:$DOCKER_IMAGE_TAG
+    - docker tag $DOCKER_IMAGE:$DOCKER_IMAGE_TAG $DOCKER_CACHE_IMAGE
+    - docker push $DOCKER_CACHE_IMAGE
+    - collapseable_section_end "docker-push"
+  cache:
+    - key: www-yarn
+      policy: pull
+      paths:
+        - www/.yarn
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - if: $CI_COMMIT_BRANCH == "next"
+  needs:
+    - job: 🐳 catladder image docker-build
+      artifacts: false
+      optional: true
+    - 'www 🔨 app | next '
+  retry: *a2
+  interruptible: true
+'www 🚀 Deploy | next ':
+  stage: deploy next
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export ENV_SHORT="next"
+    - export APP_DIR="www"
+    - export ENV_TYPE="dev"
+    - export BUILD_INFO_BUILD_ID="$(git describe --tags 2>/dev/null || git rev-parse HEAD)"
+    - export BUILD_INFO_BUILD_TIME="$CI_JOB_STARTED_AT"
+    - export BUILD_INFO_CURRENT_VERSION="$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")"
+    - export HOSTNAME="pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export HOSTNAME_INTERNAL="pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export ROOT_URL_INTERNAL="https://pan-test-app-next-www-123456789012.europe-west6.run.app"
+    - export DEPLOY_CLOUD_RUN_SERVICE_NAME="pan-test-app-next-www"
+    - export DEPLOY_CLOUD_RUN_PROJECT_ID="google-project-id"
+    - export DEPLOY_CLOUD_RUN_REGION="europe-west6"
+    - export GCLOUD_DEPLOY_credentialsKey="$CL_next_www_GCLOUD_DEPLOY_credentialsKey"
+    - export _ALL_ENV_VAR_KEYS="[\\"ENV_SHORT\\",\\"APP_DIR\\",\\"ENV_TYPE\\",\\"BUILD_INFO_BUILD_ID\\",\\"BUILD_INFO_BUILD_TIME\\",\\"BUILD_INFO_CURRENT_VERSION\\",\\"HOSTNAME\\",\\"ROOT_URL\\",\\"HOSTNAME_INTERNAL\\",\\"ROOT_URL_INTERNAL\\",\\"DEPLOY_CLOUD_RUN_SERVICE_NAME\\",\\"DEPLOY_CLOUD_RUN_PROJECT_ID\\",\\"DEPLOY_CLOUD_RUN_REGION\\",\\"GCLOUD_DEPLOY_credentialsKey\\"]"
+    - export DOCKER_REGISTRY="europe-west6-docker.pkg.dev"
+    - export DOCKER_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www"
+    - export DOCKER_CACHE_IMAGE="europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www"
+    - export DOCKER_IMAGE_TAG="$CI_COMMIT_SHA"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - collapseable_section_start "prepare" "Prepare..."
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_next_www_GCLOUD_DEPLOY_credentialsKey")
+    - collapseable_section_end "prepare"
+    - collapseable_section_start "writeenvvars" "Write env vars to file"
+    - |
+      cat > ____envvars.yaml <<EOF
+      ENV_SHORT: |-
+        next
+      APP_DIR: |-
+        www
+      ENV_TYPE: |-
+        dev
+      BUILD_INFO_BUILD_ID: |-
+        $(printf %s "$(git describe --tags 2>/dev/null || git rev-parse HEAD)" | sed '1!s/^/  /')
+      BUILD_INFO_BUILD_TIME: |-
+        $(printf %s "$CI_JOB_STARTED_AT" | sed '1!s/^/  /')
+      BUILD_INFO_CURRENT_VERSION: |-
+        $(printf %s "$(tag=$(git ls-remote origin "refs/tags/v*[0-9]" 2>/dev/null | cut -f 2- | sort -V | tail -1 | sed 's/refs\\/tags\\/v//'); [ -z "$tag" ] && echo "0.0.0" || echo "$tag")" | sed '1!s/^/  /')
+      HOSTNAME: |-
+        pan-test-app-next-www-123456789012.europe-west6.run.app
+      ROOT_URL: |-
+        https://pan-test-app-next-www-123456789012.europe-west6.run.app
+      HOSTNAME_INTERNAL: |-
+        pan-test-app-next-www-123456789012.europe-west6.run.app
+      ROOT_URL_INTERNAL: |-
+        https://pan-test-app-next-www-123456789012.europe-west6.run.app
+      DEPLOY_CLOUD_RUN_SERVICE_NAME: |-
+        pan-test-app-next-www
+      DEPLOY_CLOUD_RUN_PROJECT_ID: |-
+        google-project-id
+      DEPLOY_CLOUD_RUN_REGION: |-
+        europe-west6
+      _ALL_ENV_VAR_KEYS: |-
+        ["ENV_SHORT","APP_DIR","ENV_TYPE","BUILD_INFO_BUILD_ID","BUILD_INFO_BUILD_TIME","BUILD_INFO_CURRENT_VERSION","HOSTNAME","ROOT_URL","HOSTNAME_INTERNAL","ROOT_URL_INTERNAL","DEPLOY_CLOUD_RUN_SERVICE_NAME","DEPLOY_CLOUD_RUN_PROJECT_ID","DEPLOY_CLOUD_RUN_REGION","GCLOUD_DEPLOY_credentialsKey"]
+
+      EOF
+    - collapseable_section_end "writeenvvars"
+    - collapseable_section_start "deploy" "Deploy to cloud run"
+    - gcloud run deploy pan-test-app-next-www --command="yarn,start" --image=europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www:$DOCKER_IMAGE_TAG --project=google-project-id --region=europe-west6 --labels=customer-name=pan,component-name=www,app-name=test-app,env-type=dev,env-name=next,build-type=node,cloud-run-service-name=pan-test-app-next-www --env-vars-file=____envvars.yaml --min-instances=0 --max-instances=100 --cpu-throttling --allow-unauthenticated --ingress=all --cpu-boost
+    - collapseable_section_end "deploy"
+    - collapseable_section_start "cleanup" "Cleanup"
+    - set +e
+    - gcloud run revisions list --project=google-project-id --region=europe-west6 --service=pan-test-app-next-www --limit=unlimited --sort-by=metadata.creationTimestamp --format="value(name)" --filter='(status.conditions.status=False OR status.conditions.status=Unknown)' | while read -r revisionname; do gcloud run revisions delete --project=google-project-id --region=europe-west6 --quiet $revisionname ; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www@$version --quiet --delete-tags; done
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+    - collapseable_section_end "cleanup"
+    - echo "CL_GITLAB_ENVIRONMENT_URL=$ROOT_URL" >> gitlab_environment.env
+  environment:
+    name: next/www
+    url: $CL_GITLAB_ENVIRONMENT_URL
+    on_stop: 'www 🛑 Stop ⚠️ | next '
+    auto_stop_in: 4 weeks
+  artifacts:
+    reports:
+      dotenv: gitlab_environment.env
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: on_success
+      if: $CI_COMMIT_BRANCH == "next"
+  needs:
+    - job: 'www 👮 lint | next '
+      artifacts: false
+    - job: 'www 🔨 app | next '
+      artifacts: false
+    - job: 'www 🔨 docker | next '
+      artifacts: false
+    - job: 'www 🧪 test | next '
+      artifacts: false
+    - job: 'www 🛡 audit | next '
+      artifacts: false
+  retry: *a2
+  interruptible: true
+  allow_failure: false
+'www 🛑 Stop ⚠️ | next ':
+  stage: stop next
+  image: google/cloud-sdk:525.0.0
+  variables:
+    KUBERNETES_CPU_REQUEST: '0.22'
+    KUBERNETES_MEMORY_REQUEST: 200Mi
+    KUBERNETES_MEMORY_LIMIT: 400Mi
+    GIT_STRATEGY: none
+  script:
+    - collapseable_section_start "injectvars" "Injecting variables"
+    - export CLOUDSDK_CORE_DISABLE_PROMPTS="1"
+    - collapseable_section_end "injectvars"
+    - set +e
+    - gcloud auth activate-service-account --key-file=<(echo "$CL_next_www_GCLOUD_DEPLOY_credentialsKey")
+    - gcloud run services delete pan-test-app-next-www --project=google-project-id --region=europe-west6
+    - gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/next/www --quiet --delete-tags
+    - gcloud artifacts docker images list europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www --sort-by=~CREATE_TIME --format="value(version)" | tail -n +2 | while read -r version; do gcloud artifacts docker images delete europe-west6-docker.pkg.dev/google-project-id/catladder-deploy/pan-test-app/caches/www@$version --quiet --delete-tags; done
+    - set -e
+  environment:
+    name: next/www
+    action: stop
+  rules:
+    - when: never
+      if: $CI_PIPELINE_SOURCE  == "trigger"
+    - when: manual
+      if: $CI_COMMIT_BRANCH == "next"
+  needs: []
+  retry: *a2
+  interruptible: true
+  allow_failure: true
+"
+`;

--- a/packages/pipeline/examples/env-triggers.test.ts
+++ b/packages/pipeline/examples/env-triggers.test.ts
@@ -1,0 +1,19 @@
+import { it, expect } from "vitest";
+import {
+  createYamlGithubWorkflows,
+  createYamlLocalPipeline,
+} from "./__utils__/helpers";
+import config from "./env-triggers";
+
+/**
+ * This test is auto-generated.
+ * Modifications will be overwritten on every `yarn test` run!
+ */
+
+it("matches snapshot for env-triggers local pipeline YAML", async () => {
+  expect(await createYamlLocalPipeline(config)).toMatchSnapshot();
+});
+
+it("matches snapshot for env-triggers github workflows YAML", async () => {
+  expect(await createYamlGithubWorkflows(config)).toMatchSnapshot();
+});

--- a/packages/pipeline/examples/env-triggers.ts
+++ b/packages/pipeline/examples/env-triggers.ts
@@ -1,0 +1,62 @@
+import type { Config } from "../src";
+
+/**
+ * explicit environment configuration: the top-level `environments`
+ * config declares envs project-wide and controls when they deploy
+ * (`on`) and their `autoStop`; components only carry per-component
+ * overrides. Deploy-level policy like cloud run's `revisionsToKeep`
+ * lives in the deploy config.
+ *
+ * The env type only supplies defaults — everything here overrides them:
+ * - review keeps its MR trigger but auto-stops after 3 days (default 1 week)
+ * - dev never auto-stops for the www component (default 4 weeks)
+ * - prod keeps only 2 rollback revisions (default 5)
+ * - `next` is a stable extra env deploying on pushes to the `next`
+ *   branch; every component deploys to it (opt out with `env.next: false`)
+ */
+const config = {
+  appName: "test-app",
+  customerName: "pan",
+  pipelines: {
+    gitlab: true,
+    github: true,
+  },
+  environments: {
+    review: {
+      autoStop: "3 days",
+    },
+    next: {
+      type: "dev",
+      on: { branch: "next" },
+    },
+  },
+  components: {
+    www: {
+      dir: "www",
+      build: {
+        type: "node",
+      },
+      deploy: {
+        type: "google-cloudrun",
+        projectId: "google-project-id",
+        region: "europe-west6",
+      },
+      env: {
+        dev: {
+          autoStop: false,
+        },
+        prod: {
+          deploy: {
+            revisionsToKeep: 2,
+          },
+        },
+      },
+    },
+  },
+} satisfies Config<{ CustomEnvs: "next" }>;
+
+export default config;
+
+export const information = {
+  title: "Custom: Env triggers and autoStop",
+};

--- a/packages/pipeline/src/backends/github/GithubBackend.ts
+++ b/packages/pipeline/src/backends/github/GithubBackend.ts
@@ -1,8 +1,14 @@
 import { readdir, rm, unlink } from "fs/promises";
 import { join } from "path";
 import { createAllJobs } from "../../pipeline/createAllJobs";
-import type { Config, Context, PipelineTrigger } from "../../types";
-import { ALL_PIPELINE_TRIGGERS } from "../../types/config";
+import type {
+  Config,
+  Context,
+  EnvPipelineTrigger,
+  PipelineTrigger,
+} from "../../types";
+import { ALL_PIPELINE_TRIGGERS, isBranchTrigger } from "../../types/config";
+import { getConfiguredBranchTriggers } from "../../config/configruedEnvs";
 import type { GithubJob, GithubWorkflow } from "../../types/github-types";
 import type { CatladderJob } from "../../types/jobs";
 import type { PipelineBackend, PipelineFile } from "../types";
@@ -63,6 +69,16 @@ const TRIGGER_WORKFLOWS: Record<
     on: { push: { tags: ["v*"] }, workflow_dispatch: {} },
   },
 };
+
+const getTriggerWorkflow = (
+  trigger: EnvPipelineTrigger,
+): Pick<GithubWorkflow, "name" | "on" | "concurrency"> =>
+  isBranchTrigger(trigger)
+    ? {
+        name: `🛠️ catladder ${trigger.branch}`,
+        on: { push: { branches: [trigger.branch] } },
+      }
+    : TRIGGER_WORKFLOWS[trigger];
 
 export class GithubBackend implements PipelineBackend {
   readonly type = "github" as const;
@@ -130,7 +146,13 @@ export class GithubBackend implements PipelineBackend {
       rollback: { jobs: {}, conditions: {}, options: [], envTypes: [] },
     };
 
-    for (const trigger of ALL_PIPELINE_TRIGGERS) {
+    // branch triggers (envs with `on: { branch: ... }`) each get their
+    // own push-triggered workflow next to the built-in ones
+    const allTriggers: EnvPipelineTrigger[] = [
+      ...ALL_PIPELINE_TRIGGERS,
+      ...getConfiguredBranchTriggers(config),
+    ];
+    for (const trigger of allTriggers) {
       const allJobs = await createAllJobs({
         config,
         trigger,
@@ -288,7 +310,7 @@ export class GithubBackend implements PipelineBackend {
       if (Object.keys(jobs).length > 0) {
         const workflowJobs = { ...makeEnsureImageGithubJobs(images), ...jobs };
         workflows[`${GENERATED_FILE_PREFIX}${workflowFileName(trigger)}`] = {
-          ...TRIGGER_WORKFLOWS[trigger],
+          ...getTriggerWorkflow(trigger),
           ...workflowPermissions(images),
           env: workflowEnv,
           // the review workflow additionally gets the aggregate job —
@@ -398,7 +420,12 @@ const workflowPermissions = (_images: JobImagesPlan) => ({
   permissions: { contents: "read", packages: "write" },
 });
 
-const workflowFileName = (trigger: PipelineTrigger): string => {
+const workflowFileName = (trigger: EnvPipelineTrigger): string => {
+  if (isBranchTrigger(trigger)) {
+    // branch names may contain characters that don't belong in a file
+    // name (e.g. "release/next")
+    return `branch-${trigger.branch.replace(/[^a-zA-Z0-9]+/g, "-")}.yml`;
+  }
   switch (trigger) {
     case "mr":
       return "review.yml";
@@ -417,7 +444,9 @@ const workflowFileName = (trigger: PipelineTrigger): string => {
 const isReviewStopJob = (context: Context, job: CatladderJob) =>
   job.environment?.action === "stop" &&
   context.type === "component" &&
-  context.environment.envType === "review";
+  // a review app (one instance per pull request) is torn down when its
+  // pull request closes; stable envs get dispatch-triggered stop jobs
+  context.environment.instance.type === "review";
 
 /**
  * stop/rollback jobs of non-review environments have no automatic

--- a/packages/pipeline/src/backends/gitlab/GitlabBackend.ts
+++ b/packages/pipeline/src/backends/gitlab/GitlabBackend.ts
@@ -8,13 +8,14 @@ import {
 import type {
   ComponentContext,
   Config,
+  EnvPipelineTrigger,
   GitlabJobDef,
   GitlabRule,
   Pipeline,
-  PipelineTrigger,
   WorkspaceContext,
 } from "../../types";
-import { ALL_PIPELINE_TRIGGERS } from "../../types/config";
+import { ALL_PIPELINE_TRIGGERS, isBranchTrigger } from "../../types/config";
+import { getConfiguredBranchTriggers } from "../../config/configruedEnvs";
 import { createAllJobs } from "../../pipeline/createAllJobs";
 import { JobImagesPlan } from "../../customImages/jobImagesPlan";
 import { getCatciGeneratedFiles } from "../../catci/shippedCatci";
@@ -158,9 +159,16 @@ export class GitlabBackend implements PipelineBackend {
     // main-branch job list for the queued-release executor's needs.
     images.resolveRef({ catladderImage: getReleaseMethod(config).image });
 
-    // for all triggers create jobs and add base rules
+    // for all triggers create jobs and add base rules. Branch triggers
+    // (envs with `on: { branch: ... }`) each get their own pipeline next
+    // to the built-in ones.
+    const branchTriggers = getConfiguredBranchTriggers(config);
+    const allTriggers: EnvPipelineTrigger[] = [
+      ...ALL_PIPELINE_TRIGGERS,
+      ...branchTriggers,
+    ];
     const jobsPerTrigger = await Promise.all(
-      ALL_PIPELINE_TRIGGERS.map(async (trigger) => ({
+      allTriggers.map(async (trigger) => ({
         trigger,
         jobs: await createGitlabJobs(
           await createAllJobs({ config, trigger, pipelineType: this.type }),
@@ -271,6 +279,7 @@ export class GitlabBackend implements PipelineBackend {
         // per-pipeline-type variables (pipelines.gitlab.runnerVariables)
         ...getPipelineOptions(config, this.type).runnerVariables,
       },
+      branchPipelines: branchTriggers.map(({ branch }) => branch),
     });
   }
 }
@@ -283,10 +292,17 @@ function isManualGitlabJob(job: GitlabJobDef): boolean {
   return (job.rules ?? []).some((rule) => rule.when === "manual");
 }
 
-function getGitlabRulesForTrigger(trigger: PipelineTrigger): GitlabRule[] {
+function getGitlabRulesForTrigger(trigger: EnvPipelineTrigger): GitlabRule[] {
   // mainBranch: on push to main branch except it's a release commit
   // mr: on merge request
   // taggedRelease: on tag
+  // { branch }: on push to that specific branch
+  if (isBranchTrigger(trigger)) {
+    return [
+      RULE_NEVER_ON_AGENT_TRIGGER,
+      { if: `$CI_COMMIT_BRANCH == "${trigger.branch}"` },
+    ];
+  }
   switch (trigger) {
     case "mainBranch":
       return [

--- a/packages/pipeline/src/backends/gitlab/createGitlabJobs.ts
+++ b/packages/pipeline/src/backends/gitlab/createGitlabJobs.ts
@@ -295,7 +295,7 @@ const addGitlabEnvironment = (
     return job;
   }
   const { env, name, environment } = context;
-  const { envVars, envType } = environment;
+  const { envVars, instance } = environment;
   const { onStop, autoStopIn, action } = catladderJobEnvironment;
   // those can be dynamic, so we therefore have to do this: https://docs.gitlab.com/ee/ci/environments/#set-a-dynamic-environment-url
 
@@ -321,7 +321,7 @@ const addGitlabEnvironment = (
 
   // this is NOT a bashVariable since it NEEDS to be used as a string in gitlab
   const gitlabEnvironmentName =
-    envType === "review"
+    instance.type === "review"
       ? `${env}/$CI_COMMIT_REF_NAME/${name}` // FIXME: should be replaced with mr name as well
       : `${env}/${name}`;
 

--- a/packages/pipeline/src/backends/gitlab/createGitlabPipeline.ts
+++ b/packages/pipeline/src/backends/gitlab/createGitlabPipeline.ts
@@ -19,11 +19,15 @@ export const createGitlabPipelineWithDefaults = ({
   image,
   variables,
   before_script,
+  branchPipelines = [],
   ...config
-}: PickRequired<
-  Partial<Pipeline<"gitlab">>,
-  "stages" | "jobs"
->): Pipeline<"gitlab"> => {
+}: PickRequired<Partial<Pipeline<"gitlab">>, "stages" | "jobs"> & {
+  /**
+   * branches with their own pipeline (envs with `on: { branch: ... }`) —
+   * they get a named entry in the workflow name rules
+   */
+  branchPipelines?: string[];
+}): Pipeline<"gitlab"> => {
   return {
     image: image ?? DEFAULT_PIPELINE_IMAGE,
     variables: {
@@ -72,6 +76,13 @@ export const createGitlabPipelineWithDefaults = ({
             PIPELINE_NAME: "Main - $CI_COMMIT_TITLE",
           },
         },
+        ...branchPipelines.map((branch) => ({
+          if: `$CI_COMMIT_BRANCH == "${branch}"`,
+          variables: {
+            PIPELINE_ICON: "🐱🔨",
+            PIPELINE_NAME: `${branch} - $CI_COMMIT_TITLE`,
+          },
+        })),
 
         {
           when: "always", // fallback

--- a/packages/pipeline/src/config/__tests__/configruedEnvs.test.ts
+++ b/packages/pipeline/src/config/__tests__/configruedEnvs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getAllEnvsByTrigger } from "..";
+import { getAllEnvsByTrigger, getConfiguredBranchTriggers } from "..";
 import type { DeployConfigKubernetesCluster } from "../..";
 import type { Config } from "../../types";
 
@@ -100,6 +100,94 @@ describe("getAllEnvsByTrigger", () => {
     it("does not include disabled envs", () => {
       const envs = getAllEnvsByTrigger(SIMPLE_CONFIG, "app3", "taggedRelease");
       expect(envs).toEqual([]);
+    });
+  });
+
+  describe("project-wide `environments` config", () => {
+    const CONFIG_WITH_ENVIRONMENTS: Config = {
+      appName: "my-app",
+      customerName: "pan",
+      environments: {
+        // dev moved to a branch pipeline
+        dev: { on: { branch: "develop" } },
+        // an extra stable env deploying on pushes to `next`
+        next: { type: "dev", on: { branch: "next" } },
+        // a stage that deploys with the main branch instead of tags
+        stage: { on: "mainBranch" },
+        // an env that is in no pipeline at all
+        prod: { on: false },
+      },
+      components: {
+        app1: {
+          dir: "dir1",
+          build: { type: "node" },
+          deploy: { type: "kubernetes", cluster },
+        },
+        app2: {
+          dir: "dir2",
+          build: { type: "node" },
+          deploy: { type: "kubernetes", cluster },
+          env: {
+            next: false, // opts out of the declared env
+          },
+        },
+      },
+    };
+
+    it("`on` overrides the env type's default trigger", () => {
+      expect(
+        getAllEnvsByTrigger(CONFIG_WITH_ENVIRONMENTS, "app1", "mainBranch"),
+      ).toEqual(["stage"]);
+      expect(
+        getAllEnvsByTrigger(CONFIG_WITH_ENVIRONMENTS, "app1", "taggedRelease"),
+      ).toEqual([]);
+      expect(
+        getAllEnvsByTrigger(CONFIG_WITH_ENVIRONMENTS, "app1", "mr"),
+      ).toEqual(["review"]);
+    });
+
+    it("selects envs for branch triggers", () => {
+      expect(
+        getAllEnvsByTrigger(CONFIG_WITH_ENVIRONMENTS, "app1", {
+          branch: "develop",
+        }),
+      ).toEqual(["dev"]);
+      expect(
+        getAllEnvsByTrigger(CONFIG_WITH_ENVIRONMENTS, "app1", {
+          branch: "next",
+        }),
+      ).toEqual(["next"]);
+      expect(
+        getAllEnvsByTrigger(CONFIG_WITH_ENVIRONMENTS, "app1", {
+          branch: "other",
+        }),
+      ).toEqual([]);
+    });
+
+    it("declared envs apply to all components unless opted out", () => {
+      expect(
+        getAllEnvsByTrigger(CONFIG_WITH_ENVIRONMENTS, "app2", {
+          branch: "next",
+        }),
+      ).toEqual([]);
+    });
+
+    it("collects the configured branch triggers, deduplicated and sorted", () => {
+      expect(getConfiguredBranchTriggers(CONFIG_WITH_ENVIRONMENTS)).toEqual([
+        { branch: "develop" },
+        { branch: "next" },
+      ]);
+      expect(getConfiguredBranchTriggers(SIMPLE_CONFIG)).toEqual([]);
+    });
+
+    it("throws for a declared custom env without a type", () => {
+      const config: Config = {
+        ...CONFIG_WITH_ENVIRONMENTS,
+        environments: { sandbox: {} },
+      };
+      expect(() => getAllEnvsByTrigger(config, "app1", "mainBranch")).toThrow(
+        'environment "sandbox" needs a type',
+      );
     });
   });
 });

--- a/packages/pipeline/src/config/configruedEnvs.ts
+++ b/packages/pipeline/src/config/configruedEnvs.ts
@@ -1,5 +1,16 @@
-import type { Config, EnvType, PipelineTrigger } from "../types";
-import { DEFAULT_ENV_TYPES, getEnvTypesByTrigger } from "../types";
+import type {
+  BranchPipelineTrigger,
+  Config,
+  EnvPipelineTrigger,
+  EnvType,
+} from "../types";
+import {
+  DEFAULT_ENV_TYPES,
+  envTriggerEquals,
+  isBranchTrigger,
+  isKnowEnvType,
+} from "../types";
+import { getEnvOn } from "../context/getEnvOn";
 
 const getConfiguredAndDefaultEnvs = (
   config: Config,
@@ -14,9 +25,26 @@ const getConfiguredAndDefaultEnvs = (
     (e) => configuredEnvs[e] !== false,
   );
 
-  const configuredCustomEnvs = Object.entries(
-    config.components[componentName].env ?? {},
-  )
+  // envs declared project-wide (top-level `environments`): every
+  // component deploys to them unless it opts out with `env.<name>: false`
+  const declaredEnvs = Object.entries(config.environments ?? {})
+    .filter(([envName]) => !isKnowEnvType(envName)) // default envs are already handled above
+    .map(([envName, envConfig]) => {
+      if (!envConfig.type) {
+        throw new Error(
+          `environment "${envName}" needs a type (dev, review, stage, prod)`,
+        );
+      }
+      return [envName, envConfig.type] as const;
+    })
+    .filter(
+      ([envName, envType]) =>
+        envTypes.includes(envType) && configuredEnvs[envName] !== false,
+    )
+    .map(([envName]) => envName);
+
+  // legacy: custom envs declared per component via their `type`
+  const configuredCustomEnvs = Object.entries(configuredEnvs)
     .filter(
       ([, config]) =>
         config &&
@@ -26,7 +54,13 @@ const getConfiguredAndDefaultEnvs = (
     )
     .map(([envName]) => envName);
 
-  return [...new Set([...enabledDefaultEnvs, ...configuredCustomEnvs])];
+  return [
+    ...new Set([
+      ...enabledDefaultEnvs,
+      ...declaredEnvs,
+      ...configuredCustomEnvs,
+    ]),
+  ];
 };
 
 export const getAllEnvs = (config: Config, componentName: string) => {
@@ -41,11 +75,53 @@ export const getAllEnvsInAllComponents = (config: Config) => {
   ];
 };
 
+/**
+ * the resolved `on` of one env of a component (the project-wide `on`
+ * of the env, falling back to the env type's default trigger)
+ */
+const getEnvOnForComponentEnv = (
+  config: Config,
+  componentName: string,
+  env: string,
+) => {
+  const entry = config.components[componentName].env?.[env];
+  return getEnvOn(
+    env,
+    entry && entry !== false ? entry : {},
+    config.environments,
+  );
+};
+
 export const getAllEnvsByTrigger = (
   config: Config,
   componentName: string,
-  trigger: PipelineTrigger,
+  trigger: EnvPipelineTrigger,
 ) => {
-  const envTypesByTrigger = getEnvTypesByTrigger(trigger);
-  return getConfiguredAndDefaultEnvs(config, componentName, envTypesByTrigger);
+  return getAllEnvs(config, componentName).filter((env) =>
+    envTriggerEquals(
+      getEnvOnForComponentEnv(config, componentName, env),
+      trigger,
+    ),
+  );
+};
+
+/**
+ * all branch triggers declared by any env of any component (via
+ * `on: { branch: "..." }`), deduplicated and sorted for deterministic
+ * pipeline generation. Each gets its own pipeline next to the built-in
+ * triggers.
+ */
+export const getConfiguredBranchTriggers = (
+  config: Config,
+): BranchPipelineTrigger[] => {
+  const branches = new Set<string>();
+  for (const componentName of Object.keys(config.components)) {
+    for (const env of getAllEnvs(config, componentName)) {
+      const on = getEnvOnForComponentEnv(config, componentName, env);
+      if (on && isBranchTrigger(on)) {
+        branches.add(on.branch);
+      }
+    }
+  }
+  return [...branches].sort().map((branch) => ({ branch }));
 };

--- a/packages/pipeline/src/context/createAllComponentsContext.ts
+++ b/packages/pipeline/src/context/createAllComponentsContext.ts
@@ -1,11 +1,11 @@
 import { getAllEnvsByTrigger } from "../config/configruedEnvs";
 import type { ComponentContext, PipelineType } from "../types";
-import type { Config, PipelineTrigger } from "../types/config";
+import type { Config, EnvPipelineTrigger } from "../types/config";
 import { createComponentContext } from "./createComponentContext";
 
 export type CreateAllComponentsContextProps = {
   config: Config;
-  trigger: PipelineTrigger;
+  trigger: EnvPipelineTrigger;
   pipelineType: PipelineType;
 };
 

--- a/packages/pipeline/src/context/createComponentContext.ts
+++ b/packages/pipeline/src/context/createComponentContext.ts
@@ -5,7 +5,7 @@ import { DEPLOY_TYPES } from "../deploy";
 import type { DeployConfig, DeployConfigType } from "../deploy/types";
 import { getPackageManagerInfoForComponent } from "../pipeline/packageManager";
 import type { PipelineType } from "../types";
-import type { Config, PipelineTrigger } from "../types/config";
+import type { Config, EnvPipelineTrigger } from "../types/config";
 import type {
   BuildContext,
   BuildContextComponent,
@@ -21,7 +21,7 @@ export type CreateComponentContextContext = {
   componentName: string;
   env: string;
   pipelineType?: PipelineType;
-  trigger?: PipelineTrigger;
+  trigger?: EnvPipelineTrigger;
 };
 
 export const createComponentContext = async (

--- a/packages/pipeline/src/context/createWorkspaceContext.ts
+++ b/packages/pipeline/src/context/createWorkspaceContext.ts
@@ -1,7 +1,7 @@
 import {
   WORKSPACE_BUILD_TYPES,
   type Config,
-  type PipelineTrigger,
+  type EnvPipelineTrigger,
   type PipelineType,
   type WorkspaceContext,
 } from "..";
@@ -22,7 +22,7 @@ export async function createWorkspaceContext({
   workspaceName: string;
   config: Config;
   pipelineType: PipelineType;
-  trigger: PipelineTrigger;
+  trigger: EnvPipelineTrigger;
 }): Promise<WorkspaceContext> {
   const workspaceConfigRaw = config.builds?.[workspaceName];
   if (!workspaceConfigRaw) {

--- a/packages/pipeline/src/context/getEnvInstance.ts
+++ b/packages/pipeline/src/context/getEnvInstance.ts
@@ -1,9 +1,13 @@
-import { BashExpression, type StringOrBashExpression } from "@catladder/bash";
+import { BashExpression } from "@catladder/bash";
 import type { BashExpressionPerPipelineType } from "../bash/bashExpressionPerPipelineType";
 import { getBashExpressionPerPipelineType } from "../bash/bashExpressionPerPipelineType";
 import type { PipelineType } from "../types";
-import type { EnvConfigWithComponent } from "../types/config";
-import { getEnvType } from "./getEnvType";
+import type {
+  EnvConfigWithComponent,
+  EnvironmentConfig,
+} from "../types/config";
+import type { EnvironmentInstance } from "../types/environmentContext";
+import { getEnvOn } from "./getEnvOn";
 const REVIEW_SLUG: BashExpressionPerPipelineType = {
   default: "unknown-review-slug",
   gitlab: new BashExpression(
@@ -15,14 +19,19 @@ const REVIEW_SLUG: BashExpressionPerPipelineType = {
   ),
 };
 
-export const getReviewSlug = (
+export const getEnvInstance = (
   envConfig: EnvConfigWithComponent,
   env: string,
   pipelineType?: PipelineType,
-): StringOrBashExpression | null => {
-  const envType = getEnvType(env, envConfig);
-  if (envType === "review") {
-    return getBashExpressionPerPipelineType(REVIEW_SLUG, pipelineType);
+  environments?: Record<string, EnvironmentConfig>,
+): EnvironmentInstance => {
+  // an env deploying per merge request is a review app — one dynamic
+  // instance per MR, identified by the review slug
+  if (getEnvOn(env, envConfig, environments) === "mr") {
+    return {
+      type: "review",
+      reviewSlug: getBashExpressionPerPipelineType(REVIEW_SLUG, pipelineType),
+    };
   }
-  return null; // not a review app;
+  return { type: "stable" };
 };

--- a/packages/pipeline/src/context/getEnvOn.ts
+++ b/packages/pipeline/src/context/getEnvOn.ts
@@ -1,0 +1,29 @@
+import type { EnvironmentConfig, EnvOnConfig, EnvType } from "../types";
+import { ENV_TYPES } from "../types";
+import { getEnvType } from "./getEnvType";
+
+const getDefaultOnForType = (envType: EnvType): EnvOnConfig => {
+  const triggers = ENV_TYPES[envType].triggers as readonly EnvOnConfig[];
+  return triggers[0] ?? false;
+};
+
+/**
+ * resolves when an env deploys: the project-wide `on` config of the env
+ * (top-level `environments`), falling back to the default of its env
+ * type (dev → mainBranch, review → mr, stage/prod → taggedRelease,
+ * local → false).
+ *
+ * `on` is deliberately not configurable per component — an environment
+ * deploys at one point in time for the whole project.
+ */
+export const getEnvOn = (
+  env: string,
+  envConfig: {
+    type?: EnvType;
+  },
+  environments?: Record<string, EnvironmentConfig>,
+): EnvOnConfig => {
+  const on = environments?.[env]?.on;
+  if (on !== undefined) return on;
+  return getDefaultOnForType(getEnvType(env, envConfig, environments));
+};

--- a/packages/pipeline/src/context/getEnvType.ts
+++ b/packages/pipeline/src/context/getEnvType.ts
@@ -1,4 +1,4 @@
-import type { EnvType } from "../types";
+import type { EnvironmentConfig, EnvType } from "../types";
 import { isKnowEnvType } from "../types";
 
 export const getEnvType = (
@@ -6,8 +6,14 @@ export const getEnvType = (
   envConfig: {
     type?: EnvType;
   },
+  environments?: Record<string, EnvironmentConfig>,
 ): EnvType => {
+  // legacy: per-component custom envs declare their type themselves
   if (envConfig.type) return envConfig.type;
+
+  // project-wide declaration (top-level `environments`)
+  const declaredType = environments?.[env]?.type;
+  if (declaredType) return declaredType;
 
   if (isKnowEnvType(env)) {
     return env;

--- a/packages/pipeline/src/context/getEnvironment.ts
+++ b/packages/pipeline/src/context/getEnvironment.ts
@@ -18,8 +18,10 @@ export const getEnvironment = async (
     envType,
     fullName: envContext.fullName,
     slugPrefix: envContext.environmentSlugPrefix,
+    instance: envContext.instance,
     reviewSlug: envContext.reviewSlug,
     slug: envContext.environmentSlug,
+    autoStop: envContext.autoStop,
 
     ...variables,
   };

--- a/packages/pipeline/src/context/getEnvironmentContext.ts
+++ b/packages/pipeline/src/context/getEnvironmentContext.ts
@@ -2,17 +2,20 @@ import type { CreateComponentContextContext } from "..";
 import type { StringOrBashExpression } from "@catladder/bash";
 import { joinBashExpressions } from "@catladder/bash";
 
-import type { EnvironmentContext } from "../types/environmentContext";
+import type {
+  EnvironmentContext,
+  EnvironmentInstance,
+} from "../types/environmentContext";
 import { getEnvConfig } from "./getEnvConfig";
+import { getEnvInstance } from "./getEnvInstance";
 import { getEnvType } from "./getEnvType";
-import { getReviewSlug } from "./getReviewSlug";
 
 const getEnvironmentSlugPrefix = (
   env: string,
-  reviewSlug: StringOrBashExpression | null,
+  instance: EnvironmentInstance,
 ): StringOrBashExpression => {
-  if (reviewSlug) {
-    return joinBashExpressions([env, reviewSlug], "-");
+  if (instance.type === "review") {
+    return joinBashExpressions([env, instance.reviewSlug], "-");
   }
   return env;
 };
@@ -24,10 +27,22 @@ export const getEnvironmentContext = ({
   pipelineType,
 }: CreateComponentContextContext): EnvironmentContext => {
   const envConfigRaw = getEnvConfig(config, componentName, env);
-  const envType = getEnvType(env, envConfigRaw);
-  const reviewSlug = getReviewSlug(envConfigRaw, env, pipelineType);
+  const envType = getEnvType(env, envConfigRaw, config.environments);
+  const instance = getEnvInstance(
+    envConfigRaw,
+    env,
+    pipelineType,
+    config.environments,
+  );
 
-  const environmentSlugPrefix = getEnvironmentSlugPrefix(env, reviewSlug);
+  // component-level autoStop overrides the project-wide environment
+  // config; undefined means the env type's default applies
+  const autoStop =
+    envConfigRaw.autoStop !== undefined
+      ? envConfigRaw.autoStop
+      : config.environments?.[env]?.autoStop;
+
+  const environmentSlugPrefix = getEnvironmentSlugPrefix(env, instance);
 
   const environmentSlug = environmentSlugPrefix.concat(`-${componentName}`);
 
@@ -42,10 +57,12 @@ export const getEnvironmentContext = ({
     buildConfigRaw: envConfigRaw.build,
     environmentSlugPrefix,
     environmentSlug,
-    reviewSlug,
+    instance,
+    reviewSlug: instance.type === "review" ? instance.reviewSlug : null,
     pipelineType,
     fullName,
     envType,
+    autoStop,
     componentName,
     env,
     fullConfig: config,

--- a/packages/pipeline/src/deploy/base/deploy.ts
+++ b/packages/pipeline/src/deploy/base/deploy.ts
@@ -21,12 +21,20 @@ export class DeployJob extends CatladderJob {
     const hasDocker = requiresDockerBuild(context);
     const isStoppable = contextIsStoppable(context);
 
-    const autoStop =
+    // env-level autoStop config wins; the env type only supplies the default
+    const autoStopConfigured = context.environment.autoStop;
+    const autoStopDefault =
       context.environment.envType === "review"
         ? "1 week"
         : context.environment.envType === "dev"
           ? "4 weeks"
           : undefined;
+    const autoStop =
+      autoStopConfigured === undefined
+        ? autoStopDefault
+        : autoStopConfigured === false
+          ? undefined
+          : autoStopConfigured;
 
     const deployConfig = context.deploy?.config;
 

--- a/packages/pipeline/src/deploy/cloudRun/artifactsRegistry.ts
+++ b/packages/pipeline/src/deploy/cloudRun/artifactsRegistry.ts
@@ -36,7 +36,8 @@ export const getArtifactsRegistryImageName = (
   context: ComponentContext,
   lecacyReviewImageName = false,
 ) => {
-  if (lecacyReviewImageName && context.environment.envType !== "review") {
+  const { instance } = context.environment;
+  if (lecacyReviewImageName && instance.type !== "review") {
     throw new Error("lecacyReviewImageName is only allowed for review app");
   }
 
@@ -45,8 +46,8 @@ export const getArtifactsRegistryImageName = (
     dockerUrl,
     context.env,
     context.name,
-    ...(context.environment.reviewSlug && !lecacyReviewImageName
-      ? [context.environment.reviewSlug]
+    ...(instance.type === "review" && !lecacyReviewImageName
+      ? [instance.reviewSlug]
       : []),
   ];
   return joinBashExpressions(gcloudImagePath, "/");
@@ -114,7 +115,7 @@ export const getDeleteUnusedImagesCommands = (
     // because a recent version of catladder had no review-slug in the image name, we have to delete those as well
     // we can later remove this line in some months
 
-    ...(context.environment.envType === "review"
+    ...(context.environment.instance.type === "review"
       ? allowFailureInScripts(
           getDeleteImageCommands(
             getArtifactsRegistryImageName(context, true),

--- a/packages/pipeline/src/deploy/cloudRun/cleanup.ts
+++ b/packages/pipeline/src/deploy/cloudRun/cleanup.ts
@@ -12,8 +12,17 @@ export const getRemoveOldRevisionsAndImagesCommand = (
     return getDeleteUnusedImagesCommands(context);
   }
 
-  // this number only targets inactive revisions
-  const revisionsToKeep = context.environment.envType === "prod" ? 5 : 0;
+  const deployConfig = context.deploy?.config;
+  const configuredRevisionsToKeep =
+    deployConfig && deployConfig.type === "google-cloudrun"
+      ? deployConfig.revisionsToKeep
+      : undefined;
+
+  // this number only targets inactive revisions; the env type only
+  // supplies the default (prod keeps a rollback history)
+  const revisionsToKeep =
+    configuredRevisionsToKeep ??
+    (context.environment.envType === "prod" ? 5 : 0);
 
   // this number needs to be higher than inactive after deploy, so we add one
   const imagesToKeep = revisionsToKeep + 1;

--- a/packages/pipeline/src/deploy/cloudRun/utils/getServiceName.ts
+++ b/packages/pipeline/src/deploy/cloudRun/utils/getServiceName.ts
@@ -240,7 +240,7 @@ const fromComponentContext = (context: ComponentContext): ServiceNameInput => {
     environmentSlugPrefix: context.environment.slugPrefix,
     componentName: context.name,
     env: context.env,
-    isReviewEnv: context.environment.envType === "review",
+    isReviewEnv: context.environment.instance.type === "review",
     deployConfig:
       deployConfig && deployConfig.type === "google-cloudrun"
         ? deployConfig
@@ -256,7 +256,7 @@ const fromEnvironmentContext = (
   environmentSlugPrefix: context.environmentSlugPrefix,
   componentName: context.componentName,
   env: context.env,
-  isReviewEnv: context.envType === "review",
+  isReviewEnv: context.instance.type === "review",
   deployConfig: context.deployConfigRaw || null,
   config: context.fullConfig,
 });

--- a/packages/pipeline/src/deploy/kubernetes/index.ts
+++ b/packages/pipeline/src/deploy/kubernetes/index.ts
@@ -15,11 +15,10 @@ export const KUBERNETES_DEPLOY_TYPE: DeployTypeDefinition<DeployConfigKubernetes
       fullConfig,
       deployConfigRaw,
       env,
-      reviewSlug,
-      envType,
+      instance,
     }) => {
       const KUBE_APP_NAME_PREFIX =
-        envType === "review" && reviewSlug ? reviewSlug.concat("-") : "";
+        instance.type === "review" ? instance.reviewSlug.concat("-") : "";
       const KUBE_APP_NAME = KUBE_APP_NAME_PREFIX.concat(componentName);
       const KUBE_NAMESPACE = getKubernetesNamespace(fullConfig, env);
       const componentSlug = slugify(componentName);
@@ -32,7 +31,7 @@ export const KUBERNETES_DEPLOY_TYPE: DeployTypeDefinition<DeployConfigKubernetes
       const HOSTNAME_INTERNAL = joinBashExpressions(
         [
           componentSlug,
-          ...(envType === "review" && reviewSlug ? [reviewSlug] : []),
+          ...(instance.type === "review" ? [instance.reviewSlug] : []),
           env,
           fullConfig.appName,
           fullConfig.customerName,

--- a/packages/pipeline/src/deploy/pages/deployJob.ts
+++ b/packages/pipeline/src/deploy/pages/deployJob.ts
@@ -15,7 +15,8 @@ export const createPagesDeployJobs = async (
     throw new Error("deploy config is not pages");
   }
   const onGithub = context.pipelineType === "github";
-  if (onGithub && context.environment.envType === "review") {
+  const isReviewApp = context.environment.instance.type === "review";
+  if (onGithub && isReviewApp) {
     // github pages serves ONE site per repository and deploy-pages
     // replaces all of it — there is no path_prefix equivalent, so per-PR
     // previews cannot exist (deploy-pages has a `preview` input, but it
@@ -29,8 +30,7 @@ export const createPagesDeployJobs = async (
 
   // review environments publish under their own path prefix (gitlab
   // parallel deployments) — every merge request gets a site preview
-  const pathPrefix =
-    context.environment.envType === "review" ? "mr-$CI_MERGE_REQUEST_IID" : "";
+  const pathPrefix = isReviewApp ? "mr-$CI_MERGE_REQUEST_IID" : "";
   const publishDir = deployConfig.publishDir ?? "public";
 
   const packageManagerInstall = await getPackageManagerInstall(context, {

--- a/packages/pipeline/src/deploy/types/googleCloudRun.ts
+++ b/packages/pipeline/src/deploy/types/googleCloudRun.ts
@@ -526,6 +526,16 @@ export type DeployConfigCloudRun = Omit<DeployConfigBase, "execute"> & {
   };
 
   /**
+   * how many inactive cloud run revisions to keep after a deploy — the
+   * rollback history. Older revisions and their images are deleted by
+   * the post-deploy cleanup (images keep one more than revisions, for
+   * the currently serving one).
+   *
+   * defaults to 5 for prod envs, 0 for every other environment
+   */
+  revisionsToKeep?: number;
+
+  /**
    * add cloudSql
    */
   cloudSql?: DeployConfigCloudRunCloudSql | false;

--- a/packages/pipeline/src/types/config.ts
+++ b/packages/pipeline/src/types/config.ts
@@ -21,6 +21,37 @@ export const ALL_PIPELINE_TRIGGERS = [
 export type PipelineTrigger = (typeof ALL_PIPELINE_TRIGGERS)[number];
 
 /**
+ * a pipeline that runs on pushes to one specific branch (in addition to
+ * the built-in triggers). Declared by an env via its `on` config.
+ */
+export type BranchPipelineTrigger = { branch: string };
+
+/**
+ * everything a pipeline (and therefore an env's jobs) can run on
+ */
+export type EnvPipelineTrigger = PipelineTrigger | BranchPipelineTrigger;
+
+/**
+ * the `on` config of an env: a trigger, or `false` for an env that is
+ * not part of any pipeline (like `local`)
+ */
+export type EnvOnConfig = EnvPipelineTrigger | false;
+
+export const isBranchTrigger = (
+  trigger: EnvPipelineTrigger,
+): trigger is BranchPipelineTrigger =>
+  typeof trigger === "object" && trigger !== null && "branch" in trigger;
+
+export const envTriggerEquals = (
+  a: EnvOnConfig | undefined,
+  b: EnvPipelineTrigger,
+): boolean => {
+  if (a === undefined || a === false) return false;
+  if (isBranchTrigger(b)) return isBranchTrigger(a) && a.branch === b.branch;
+  return a === b;
+};
+
+/**
  * all env types with their trigger.
  * Each env type has a default env with the same name which is always included
  */
@@ -41,18 +72,6 @@ export const ENV_TYPES = {
     triggers: [],
   },
 } as const;
-
-/**
- *
- * @param trigger a trigger
- * @returns array of env types for that trigger. this is also the list of default envs
- */
-export const getEnvTypesByTrigger = (trigger: PipelineTrigger) =>
-  Object.entries(ENV_TYPES)
-    .filter(([, e]) =>
-      (e.triggers as readonly PipelineTrigger[]).includes(trigger),
-    )
-    .map(([e]) => e as EnvType);
 
 export const DEFAULT_ENVS = Object.keys(ENV_TYPES);
 export const DEFAULT_ENV_TYPES = DEFAULT_ENVS as EnvType[];
@@ -152,7 +171,58 @@ export type EnvConfig<E extends EnvType = EnvType> = {
    * host that is used. If not set, a "canonical" url is created
    */
   host?: string;
+  /**
+   * per-component override of the environment's autoStop (see
+   * {@link EnvironmentConfig.autoStop} — each component has its own
+   * gitlab environment, so the duration may differ per component)
+   */
+  autoStop?: string | false;
 } & PartialDeep<DefaultEnvConfig>;
+
+/**
+ * project-wide declaration and tuning of an environment (the top-level
+ * `environments` config). Environments are a project-wide concept —
+ * every component deploys to a declared env unless it opts out with
+ * `env.<name>: false`. Anything that must be consistent across
+ * components (which envs exist, when they deploy) lives here; the
+ * per-component `env.<name>` entries only override component-local
+ * things (vars, deploy settings, host, autoStop).
+ */
+export type EnvironmentConfig = {
+  /**
+   * type of the env (stage, prod, review, dev) — supplies the defaults
+   * (trigger, autoStop, deploy policy). Required for envs whose name is
+   * not itself an env type.
+   */
+  type?: EnvType;
+
+  /**
+   * when this env deploys. Defaults from the env type:
+   * - dev: "mainBranch" (pushes to the default branch)
+   * - review: "mr" (merge requests / pull requests; the env is created
+   *   per MR and torn down when it closes)
+   * - stage / prod: "taggedRelease" (release tags)
+   * - local: false (not part of any pipeline)
+   *
+   * `{ branch: "next" }` deploys the env on pushes to that branch —
+   * one stable environment tracking a long-lived branch.
+   *
+   * `false` removes the env from all pipelines.
+   */
+  on?: EnvOnConfig;
+
+  /**
+   * how long the environment stays up after its last deployment before
+   * gitlab stops it automatically (gitlab `auto_stop_in`, e.g. "3 days").
+   * `false` disables auto-stopping. Defaults from the env type:
+   * review "1 week", dev "4 weeks", everything else never.
+   *
+   * Only applies to stoppable deployments, and only on gitlab (github
+   * review apps stop when their pull request closes). Components can
+   * override it per env (`env.<name>.autoStop`).
+   */
+  autoStop?: string | false;
+};
 
 export type EnvConfigWithComponent = EnvConfig<EnvType> & ComponentConfig;
 
@@ -172,7 +242,7 @@ export type Env<C extends ConfigProps = never> = {
   // unfortunatly, typescript does not properly support objects with a mix of known and unknown properties.
   // for backwards compatiblity we allow unknown props, but we cannot type it (typescript problem)
   // however, we now support providing custom envs through a generic parameter of `Config`
-} & Record<C["CustomEnvs"], CustomEnv> &
+} & Partial<Record<C["CustomEnvs"], EnvConfigWithOverride | false>> &
   Record<string, any>;
 export type ComponentConfig<C extends ConfigProps = never> = {
   /**
@@ -362,6 +432,20 @@ export type Config<C extends ConfigProps = never> = {
 
   // shared workspace Builds
   builds?: Record<string, WorkspaceBuildConfig>;
+
+  /**
+   * project-wide environment declarations and tuning. Environments are
+   * shared across all components, so everything that must be consistent
+   * between them (which envs exist, their type, when they deploy) is
+   * declared here — components only carry per-component overrides.
+   *
+   * - tune a default env: `environments: { review: { autoStop: "3 days" } }`
+   * - declare an extra env (every component deploys to it unless it
+   *   opts out with `env.<name>: false`):
+   *   `environments: { next: { type: "dev", on: { branch: "next" } } }`
+   */
+  environments?: Record<string, EnvironmentConfig>;
+
   /**
    * components (sub apps)
    */

--- a/packages/pipeline/src/types/context.ts
+++ b/packages/pipeline/src/types/context.ts
@@ -11,9 +11,10 @@ import type { AgentConfig } from "./agent";
 import type {
   ComponentConfig,
   Config,
+  EnvPipelineTrigger,
   EnvType,
-  PipelineTrigger,
 } from "./config";
+import type { EnvironmentInstance } from "./environmentContext";
 import type { BaseStage, CatladderJob, CatladderJobSpec } from "./jobs";
 import type { PipelineType } from "./pipeline";
 
@@ -49,7 +50,13 @@ export type Environment = {
    */
   slugPrefix: StringOrBashExpression;
   /**
+   * how the env is instantiated — `instance.type === "review"` is the
+   * way to find out whether this is a review app
+   */
+  instance: EnvironmentInstance;
+  /**
    * the review slug, if it is a review app, null otherwise
+   * @deprecated use `instance` — the review variant carries the slug
    */
   reviewSlug: StringOrBashExpression | null;
   /**
@@ -58,6 +65,13 @@ export type Environment = {
   slug: StringOrBashExpression;
 
   envType: EnvType;
+
+  /**
+   * the resolved `autoStop` config (component override, then the
+   * project-wide environment config — see {@link EnvironmentConfig.autoStop});
+   * undefined means the env type's default applies
+   */
+  autoStop?: string | false;
 } & EnvironmentEnvVarPart;
 
 export type YarnWorkspace = {
@@ -191,7 +205,7 @@ export type ComponentContext<
   fullConfig: Config;
   environment: Environment;
 
-  trigger?: PipelineTrigger;
+  trigger?: EnvPipelineTrigger;
   pipelineType?: PipelineType;
 
   packageManagerInfo: Promise<PackageManagerInfoComponent>;
@@ -230,7 +244,7 @@ export type WorkspaceContext = {
   packageManagerInfo: Promise<PackageManagerInfoBase>;
   components: Array<ComponentContext>;
   build: BuildContextWorkspace;
-  trigger: PipelineTrigger;
+  trigger: EnvPipelineTrigger;
   pipelineType: PipelineType;
   env: string;
 };

--- a/packages/pipeline/src/types/environmentContext.ts
+++ b/packages/pipeline/src/types/environmentContext.ts
@@ -4,6 +4,16 @@ import type { DeployConfig } from "../deploy";
 import type { Config, EnvConfigWithComponent, EnvType } from "./config";
 import type { PipelineType } from "./pipeline";
 
+/**
+ * how an environment is instantiated:
+ * - "stable": one long-lived instance (dev, stage, prod, branch envs)
+ * - "review": one instance per merge/pull request (`on: "mr"`),
+ *   addressed by the runtime review slug (mr<iid> / pr<number>)
+ */
+export type EnvironmentInstance =
+  | { type: "stable" }
+  | { type: "review"; reviewSlug: StringOrBashExpression };
+
 export type EnvironmentContext<
   B extends BuildConfig = BuildConfig,
   D extends DeployConfig = DeployConfig,
@@ -14,6 +24,11 @@ export type EnvironmentContext<
 
   env: string;
   envType: EnvType;
+  /**
+   * the resolved autoStop config (component override, then project-wide
+   * environment config); undefined means the env type's default applies
+   */
+  autoStop?: string | false;
   componentName: string;
   fullName: StringOrBashExpression;
   /**
@@ -21,7 +36,13 @@ export type EnvironmentContext<
    */
   environmentSlugPrefix: StringOrBashExpression;
   /**
+   * how the env is instantiated — `instance.type === "review"` is the
+   * way to find out whether this is a review app
+   */
+  instance: EnvironmentInstance;
+  /**
    * the review slug, if it is a review app, null otherwise
+   * @deprecated use `instance` — the review variant carries the slug
    */
   reviewSlug: StringOrBashExpression | null;
   /**

--- a/skills/catladder-config/SKILL.md
+++ b/skills/catladder-config/SKILL.md
@@ -33,6 +33,10 @@ const config = {
   appName: "my-app",
   customerName: "pan",
   pipelines: { gitlab: true, github: true }, // which CI systems to generate
+  environments: {              // optional: project-wide env declarations/tuning
+    review: { autoStop: "3 days" },
+    next: { type: "dev", on: { branch: "next" } }, // extra branch-tracking env
+  },
   components: {
     www: {
       dir: "frontend",          // working directory of this component
@@ -59,8 +63,24 @@ Key concepts:
 - **Environments**: `dev` (deployed on push to the main branch),
   `review` (per merge/pull request), `stage` and `prod` (deployed on
   tagged releases), `local` (only for local development via catenv).
-  Per-env overrides live under `env.<name>` and can override vars,
-  deploy settings, and more.
+  Environments are project-wide: the top-level `environments` config
+  declares and tunes them consistently for all components, while
+  per-component `env.<name>` entries only carry component-local
+  overrides (vars, deploy settings, host, autoStop) or `false` to opt
+  the component out. In `environments`:
+  - `on` — when the env deploys: `"mainBranch"`, `"mr"`,
+    `"taggedRelease"`, `{ branch: "next" }` (a stable env deploying on
+    pushes to that branch), or `false` (in no pipeline). `on: "mr"`
+    makes an env a review app (one instance per MR/PR, torn down on
+    close). Defaults from the env type.
+  - `autoStop` — how long a stoppable environment stays up after its
+    last deploy before gitlab stops it (e.g. `"3 days"`; `false`
+    disables). Defaults: review `"1 week"`, dev `"4 weeks"`, others
+    never. GitLab only — github review apps stop when their PR closes.
+    Components can override it per env (`env.<name>.autoStop`).
+  - Extra envs are declared with any name plus a `type` (which supplies
+    the defaults) — every component deploys to them unless it opts out:
+    `environments: { next: { type: "dev", on: { branch: "next" } } }`.
 - **Pipelines**: `pipelines: { gitlab: true, github: true }` selects
   which CI systems get generated files. Options objects instead of
   `true` allow per-pipeline settings (e.g. `runnerVariables`).

--- a/skills/catladder-deploys/SKILL.md
+++ b/skills/catladder-deploys/SKILL.md
@@ -71,6 +71,11 @@ Everything app-level lives under `values`:
   completion jobs, and always-on background worker pools.
 - `cloudSql` — attach an (unmanaged) CloudSQL instance; choose the
   connection-string format (`prisma` default, `rails`, `jdbc`).
+  `deleteDatabaseOnStop` controls whether the database is dropped when
+  the environment stops (default: true for review envs, false else).
+- `revisionsToKeep` — how many inactive revisions (the rollback
+  history) the post-deploy cleanup keeps; older revisions and their
+  images are deleted. Default: 5 on prod envs, 0 everywhere else.
 - `execute` — run a script/job/HTTP call at a deploy lifecycle point
   (`preDeploy`/`postDeploy`/`preStop`/`postStop`) or on a `schedule`.
   Prefer this over the deprecated `when`/`schedule` fields on `jobs`.

--- a/skills/catladder-pipelines/SKILL.md
+++ b/skills/catladder-pipelines/SKILL.md
@@ -11,11 +11,20 @@ generated YAML.
 
 ## Triggers and environments
 
-| Trigger | Runs on | Deploys to |
+| Trigger | Runs on | Deploys to (default) |
 |---|---|---|
 | `mainBranch` | push to the main branch | `dev` |
 | `mr` | merge/pull requests | `review` (one app per MR/PR) |
 | `taggedRelease` | git tags | `stage`, `prod` |
+| `{ branch: "<name>" }` | push to that branch | envs declaring it via `on` |
+
+The trigger of each env is its `on` in the top-level `environments`
+config (project-wide — components cannot diverge), defaulting from the
+env type as in the table. An env with `on: { branch: "next" }` gets its
+own pipeline (gitlab: rules on `$CI_COMMIT_BRANCH`; github: a
+`catladder-branch-<name>.yml` workflow) and deploys as one stable,
+branch-tracking environment — unlike review apps, it is not
+per-instance and is stopped via the manual stop job/workflow.
 
 Generated layout:
 


### PR DESCRIPTION
Decomposes the implicit env-type behavior bundle into explicit configuration, per the design concept. The env type stays as the defaults preset, so this is **non-breaking**: unchanged configs generate byte-identical pipelines (no existing snapshot changed; the repo's own `.catladder-generated/` is untouched by regeneration).

## What's new

**Top-level `environments` config** — environments are project-wide, so everything that must be consistent across components (which envs exist, when they deploy) is declared once, next to `components`, instead of per component where different components could declare conflicting configs:

```ts
environments: {
  review: { autoStop: "3 days" },                 // tune a default env
  next: { type: "dev", on: { branch: "next" } },  // declare an extra env
},
components: {
  www: {
    env: {
      dev: { autoStop: false },                    // per-component override
      prod: { deploy: { revisionsToKeep: 2 } },
      // next: false                               // per-component opt-out
    },
  },
},
```

**`on`** — when an env deploys (project-wide only):

- `"mainBranch" | "mr" | "taggedRelease"` — the built-in triggers, defaulted from the env type (dev → mainBranch, review → mr, stage/prod → taggedRelease, local → none)
- `{ branch: "next" }` — a stable environment tracking a long-lived branch, with its own pipeline: rules-guarded jobs + a named workflow rule on GitLab, a push-triggered `catladder-branch-<name>.yml` workflow on GitHub
- `false` — the env is in no pipeline

`on: "mr"` is now what makes an env a review app: the review slug and everything derived from it (k8s app names/hostnames, Cloud Run DNS-label budget, image paths, stop-on-PR-close wiring, pages previews, the GitLab environment name shape) key on the resolved trigger instead of `envType === "review"`.

**Extra envs declared in `environments` apply to every component** (an environment spans the whole app); a component opts out with `env.<name>: false`. Legacy per-component custom envs (`env.dev2: { type: "dev" }`) keep working unchanged but are no longer documented.

**`autoStop`** — GitLab `auto_stop_in` duration (e.g. `"3 days"`) or `false`; project-wide default in `environments`, per-component override in `env.<name>` (each component has its own GitLab environment). Defaults stay review `"1 week"` / dev `"4 weeks"`.

**Cloud Run `revisionsToKeep`** — the rollback history the post-deploy cleanup preserves (images keep one more); default stays 5 on prod, 0 elsewhere.

## Notes

- New example `env-triggers` snapshots the whole surface on both backends; unit tests cover `on` resolution, all-components participation/opt-out, branch-trigger collection, and the missing-type error.
- Skills (`catladder-config`, `catladder-deploys`, `catladder-pipelines`) updated in the same change.
- Deliberately unchanged: npm publish semantics (still keyed on env type prod/stage), the prod manual-deploy default, mongodb (parked for v6), GitHub's hardcoded `main` default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)